### PR TITLE
关于ast分析的一些问题

### DIFF
--- a/core/core_engine/php/engine.py
+++ b/core/core_engine/php/engine.py
@@ -21,16 +21,18 @@ def init_match_rule(data):
     try:
         object = data[0]
         match = ""
-
         if isinstance(object, php.Method) or isinstance(object, php.Function):
+            j=1
+            flag=0
+            param=[]
             function_params = object.params
             function_name = object.name
-            param = data[1]
-            index = 0
-            for function_param in function_params:
-                if function_param.name == param.name:
-                    break
-                index += 1
+            for i in range(0,len(data)//3):
+                param.append(data[j].name)
+                j+=3
+            # for function_param in function_params:
+            #     if function_param.name == param.name:
+            #         break
 
             # curl_setopt\s*\(.*,\s*CURLOPT_URL\s*,(.*)\)
             match = "(?:\A|\s|\\b)" + function_name + "\s*\("
@@ -41,10 +43,11 @@ def init_match_rule(data):
                     if function_params[i].default is not None:
                         match += "?"
 
-                if i == index:
-                    match += "([^,\)]*)"
+                if function_params[i].name in param:
+                    flag+=1
+                    match += "([^,;{]*?)"
                 else:
-                    match += "[^,\)]*"
+                    match += "[^,;{]*?"
 
             match += "\)"
 
@@ -95,4 +98,4 @@ def init_match_rule(data):
         vul_function = None
         origin_func_name = "None"
 
-    return match, match2, vul_function, index, origin_func_name
+    return match, match2, vul_function, origin_func_name

--- a/core/core_engine/php/parser.py
+++ b/core/core_engine/php/parser.py
@@ -1057,7 +1057,7 @@ def parameters_back(param, nodes, function_params=None, lineno=0,
                 param = cp
 
         elif isinstance(node, php.If):
-            # logger.debug(
+            logger.debug(
                 "[AST] param {} line {} in if/else, start ast in if/else".format(param_name, node.lineno))
 
             if isinstance(node.node, php.Block):  # if里可能是代码块，也可能就一句语句

--- a/core/core_engine/php/parser.py
+++ b/core/core_engine/php/parser.py
@@ -33,6 +33,7 @@ scan_results = []  # 结果存放列表初始化
 is_repair_functions = []  # 修复函数初始化
 is_controlled_params = []
 scan_chain = []  # 回溯链变量
+all_nodes = []
 BASE_FUNCTIONCALL_LIST = ['FunctionCall', 'MethodCall', 'StaticMethodCall', 'ObjectProperty']
 SPECIAL_FUNCTIONCALL_LIST = ['Eval', 'Echo', 'Print', 'Return', 'Break', 'Include',
                          'Require', 'Exit', 'Throw', 'Unset', 'Continue', 'Yield', 'Silence']
@@ -720,6 +721,7 @@ def parameters_back(param, nodes, function_params=None, lineno=0,
     """
     global scan_chain
     global fun_call
+    global all_nodes
     expr_lineno = 0  # source所在行号
     if hasattr(param, "name"):
         # param_name = param.name
@@ -1399,7 +1401,7 @@ def anlysis_params(param, file_path, vul_lineno, vul_function=None, repair_funct
     :param file_path: 
     :return: 
     """
-    global is_repair_functions, is_controlled_params, scan_chain
+    global is_repair_functions, is_controlled_params, scan_chain, all_nodes
     count = 0
     function_params = None
     if repair_functions is not None:

--- a/rules/autorule.py
+++ b/rules/autorule.py
@@ -72,7 +72,7 @@ class autorule:
         regex string input
         :return: 
         """
-        sql_sen = check_tuple(regex_string[0])
+        sql_sen = str(regex_string[0])
 
         if self.language.lower() == 'php':
             reg = "\$\w+"


### PR DESCRIPTION
- [x] 当污点是自定义函数且函数中有变量时不能进入函数内分析

例如以下代码：
```
<?php  
function getFilter($c,$b)
    {
        echo $c;
        $filters=$_GET['a'];
        return $filters;
    }
$d=$_GET['d'];
$a=getFilter($d,'');
    call_user_func($a, 'whoami');
?>
```
上面代码中当回溯到$d可控时应该将getFilter第一个参数标记为可控函数，然后再继续分析函数，而不是直接当作漏洞（测了一下当$d不可控时也不会分析函数，即使函数内可控）
处理赋值语句是functioncall的时候是把函数（函数返回值）当作新的变量（即污点），然后进入函数内回溯看返回值是否可控
但是当functioncall函数有参数时，分析参数是否可控的时候将本来是函数的param赋值为该参数，从而导致后面不会分析该函数
![image](https://user-images.githubusercontent.com/50451123/133016681-1a7bdebd-7cd1-4421-8d4b-4561af400322.png)

将该else分支的param参数修改为param_param，从而保证后面进入正常的函数分析流程
定义一个全局变量fun_call，当把函数赋值为参数时将fun_call赋值为True
回溯完函数并且该参数可控时，将该变量添加到可控变量列表中
因为涉及到传入调用函数的变量与该函数定义时的变量不同的情况，所以在function_back函数中先回溯该functioncall的参数并从可控函数列表中删除，然后对应到函数定义的相应位置的参数添加到可控函数列表中，回溯完函数之后再次判断fun_call并将参数从可控列表中删除

- [x] 递归分析语义树没有返回param_name和param导致的规则生成问题

例如如下情形：
```
private function filterValue(&$value, $key, $filters)
    {
        $default = array_pop($filters);
        foreach ($filters as $filter) {
            if (is_callable($filter)) {
                $value = call_user_func($filter, $value);
```
当param被赋值时，虽然将param赋值为新的参数再递归，但是没有赋值param_name参数，后面生成规则时是根据param_name来判断的，它最初匹配到关键代码`$value = call_user_func($filter, $value);`，此时的变量是$filter，而$filter是由$filters通过foreach遍历而来，此时$filters是新污点，但是最后的param_name还是$filter，影响最后的规则生成，所以param_name也增加了赋值。同时这里由于是递归，需要返回才能将最初的param_name和param参数覆盖

- [x] 找不到定义在递归节点下方的函数
例如一下代码：
```
<?php
function test()
    {
       $a=getFilter();
       call_user_func($a, 'whoami');
    }
function getFilter()
    {
        $filters=$_GET['a'];
        return $filters;
    }
test();
?>
```
传入function_back的节点是直接传的递归剩下的节点（向上递归回溯），如果函数定义在下面，那么将找不到而产生漏报。将anlysis_params函数的all_nodes（文件中所有节点）定义为全局变量，传入该函数节点时传all_nodes。

- [x] 增加一些节点的处理和多重函数调用的处理

 analysis函数中增加了php.Foreach、php.AssignOp、php.BinaryOp的处理；增加了对php.Trait、php.Foreach、php.Cast的处理；解决php.FunctionCall节点和php.Assignment下的php.FunctionCall节点不能处理多重函数调用

- [x] 一个参数可控就返回问题

如果分析到一个参数可控或在函数参数中就立即返回，问题在于如果另一个参数也可控，并且在后来的回溯中也可控，那么这个参数在后面的话，这个漏洞就会漏报，修改了一下init_match_rule函数的规则，同时去掉了’不能匹配括号’，使其能匹配下面这种形式
![image](https://user-images.githubusercontent.com/50451123/133033866-019fb588-5702-42e4-bf74-849deb14fa39.png)
