### PR TITLE
feat(web): overhaul dashboard UI, add overview endpoint and frontend enhancements

### DIFF
--- a/static/css/default.css
+++ b/static/css/default.css
@@ -7,3 +7,98 @@ ul.messages{
 ul.reset_messages{
     padding-left: 0px !important;
 }
+
+.content-wrapper {
+    background: #f4f7fb;
+}
+
+.navbar .quick-nav {
+    margin: 8px 12px;
+}
+
+.navbar .quick-nav .form-control {
+    width: 240px;
+    border-radius: 18px;
+    border: 1px solid #d2d6de;
+}
+
+.metric-grid .small-box {
+    border-radius: 10px;
+    box-shadow: 0 8px 24px rgba(31, 45, 61, 0.12);
+    transition: transform .2s ease, box-shadow .2s ease;
+}
+
+.metric-grid .small-box:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 28px rgba(31, 45, 61, 0.2);
+}
+
+.dashboard-toolbar {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 14px;
+    flex-wrap: wrap;
+}
+
+.dashboard-toolbar .status-pill {
+    display: inline-block;
+    margin-right: 6px;
+    margin-bottom: 6px;
+    border-radius: 14px;
+    padding: 4px 10px;
+    font-size: 12px;
+    background: #eef2f7;
+}
+
+.dashboard-toolbar .status-pill .num {
+    font-weight: 700;
+    margin-left: 5px;
+}
+
+.task-filter-input {
+    min-width: 260px;
+}
+
+.table .status-label {
+    min-width: 68px;
+    display: inline-block;
+}
+
+body.light-mode .main-header .navbar,
+body.light-mode .main-header .logo {
+    background: linear-gradient(120deg, #2f8dff, #3467e0);
+}
+
+body.light-mode .main-sidebar {
+    background: #1f2a39;
+}
+
+body.light-mode .sidebar-menu > li.header {
+    color: #a7b3c1;
+    background: #17202b;
+}
+
+body.dark-mode .content-wrapper {
+    background: #121820;
+    color: #d8dce4;
+}
+
+body.dark-mode .box {
+    background: #1b2330;
+    color: #d8dce4;
+    border-top-color: #3c8dbc;
+}
+
+body.dark-mode .table > tbody > tr > td,
+body.dark-mode .table > tbody > tr > th,
+body.dark-mode .table > tfoot > tr > td,
+body.dark-mode .table > tfoot > tr > th,
+body.dark-mode .table > thead > tr > td,
+body.dark-mode .table > thead > tr > th {
+    border-top-color: #2c3645;
+}
+
+body.dark-mode .table-hover > tbody > tr:hover {
+    background: #1f2b3b;
+}

--- a/static/js/dashboard-enhanced.js
+++ b/static/js/dashboard-enhanced.js
@@ -1,0 +1,106 @@
+(function () {
+  function navigateQuick(keyword) {
+    var value = (keyword || '').toLowerCase();
+    if (!value) return;
+    var routes = [
+      { keys: ['task', '任务'], url: '/dashboard/tasks/list' },
+      { keys: ['project', '项目'], url: '/dashboard/projects/list' },
+      { keys: ['rule', '规则'], url: '/dashboard/rules/list' },
+      { keys: ['vendor', '依赖'], url: '/dashboard/vendors/list' },
+      { keys: ['tamper'], url: '/dashboard/tampers/list' },
+      { keys: ['doc', '文档'], url: '/dashboard/docs' },
+      { keys: ['user', 'profile'], url: '/dashboard/userinfo' }
+    ];
+
+    for (var i = 0; i < routes.length; i++) {
+      if (routes[i].keys.some(function (k) { return value.indexOf(k) > -1; })) {
+        window.location.href = routes[i].url;
+        return;
+      }
+    }
+  }
+
+  function setTheme(mode) {
+    var body = document.body;
+    body.classList.remove('light-mode', 'dark-mode');
+    body.classList.add(mode + '-mode');
+    localStorage.setItem('dashboard_theme', mode);
+    var icon = document.getElementById('themeIcon');
+    if (icon) {
+      icon.className = mode === 'dark' ? 'fa fa-moon-o' : 'fa fa-sun-o';
+    }
+  }
+
+  function initTheme() {
+    var mode = localStorage.getItem('dashboard_theme') || 'light';
+    setTheme(mode);
+
+    var btn = document.getElementById('themeToggle');
+    if (btn) {
+      btn.addEventListener('click', function (e) {
+        e.preventDefault();
+        var nextMode = document.body.classList.contains('dark-mode') ? 'light' : 'dark';
+        setTheme(nextMode);
+      });
+    }
+  }
+
+  function initQuickSearch() {
+    var quickSearch = document.getElementById('quickSearch');
+    if (!quickSearch) return;
+
+    quickSearch.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        navigateQuick(quickSearch.value);
+      }
+    });
+  }
+
+  function initTaskFilter() {
+    var input = document.getElementById('taskFilterInput');
+    var table = document.getElementById('latestTaskTable');
+    if (!input || !table) return;
+
+    input.addEventListener('input', function () {
+      var text = input.value.toLowerCase();
+      var rows = table.querySelectorAll('tbody tr');
+      rows.forEach(function (row) {
+        row.style.display = row.innerText.toLowerCase().indexOf(text) > -1 ? '' : 'none';
+      });
+    });
+  }
+
+  function updateOverview() {
+    var panel = document.getElementById('overviewPanel');
+    if (!panel) return;
+
+    $.getJSON('/dashboard/overview', function (resp) {
+      if (resp.status !== 'ok') return;
+
+      $('#statusSuccess').text(resp.task_status.success);
+      $('#statusRunning').text(resp.task_status.running);
+      $('#statusError').text(resp.task_status.error);
+      $('#statusOther').text(resp.task_status.other);
+      $('#lastScanTime').text(resp.latest_scan_time || 'N/A');
+
+      if (resp.latest_task) {
+        $('#lastTaskName').text(resp.latest_task.task_name || ('Task #' + resp.latest_task.id));
+      }
+    });
+  }
+
+  $(document).ready(function () {
+    initTheme();
+    initQuickSearch();
+    initTaskFilter();
+
+    var refreshBtn = document.getElementById('refreshOverview');
+    if (refreshBtn) {
+      refreshBtn.addEventListener('click', function () {
+        updateOverview();
+      });
+      updateOverview();
+    }
+  });
+})();

--- a/templates/dashboard/base.html
+++ b/templates/dashboard/base.html
@@ -58,9 +58,19 @@ scratch. This page gets rid of all links and provides the needed markup only.
       <a href="#" class="sidebar-toggle" data-toggle="push-menu" role="button">
         <span class="sr-only">Toggle navigation</span>
       </a>
+      <div class="navbar-form navbar-left quick-nav hidden-xs">
+        <div class="form-group">
+          <input id="quickSearch" type="text" class="form-control" placeholder="Quick search: task / project / rule">
+        </div>
+      </div>
       <!-- Navbar Right Menu -->
       <div class="navbar-custom-menu">
         <ul class="nav navbar-nav">
+          <li>
+            <a href="#" id="themeToggle" title="Toggle theme">
+              <i id="themeIcon" class="fa fa-sun-o"></i>
+            </a>
+          </li>
           <!-- User Account Menu -->
           <li class="dropdown user user-menu">
             <!-- Menu Toggle Button -->
@@ -331,6 +341,7 @@ scratch. This page gets rid of all links and provides the needed markup only.
 <script src="{% static 'js/bootstrap.min.js' %}"></script>
 <!-- AdminLTE App -->
 <script src="{% static 'js/adminlte.min.js' %}"></script>
+<script src="{% static 'js/dashboard-enhanced.js' %}"></script>
 
 {% block script %}
 

--- a/templates/dashboard/index.html
+++ b/templates/dashboard/index.html
@@ -1,6 +1,6 @@
 {% extends "dashboard/base.html" %}
 {% block body %}
-<div class="row">
+<div class="row metric-grid">
         <div class="col-lg-2 col-xs-6">
           <!-- small box -->
           <div class="small-box bg-aqua">
@@ -91,7 +91,7 @@
         </div>
 
       </div>
-      <div class="box box-info">
+      <div class="box box-info" id="overviewPanel">
             <div class="box-header with-border">
               <h3 class="box-title">Latest Tasks</h3>
 
@@ -103,8 +103,24 @@
             </div>
             <!-- /.box-header -->
             <div class="box-body">
+              <div class="dashboard-toolbar">
+                <div>
+                  <span class="status-pill">Success <span id="statusSuccess" class="num">-</span></span>
+                  <span class="status-pill">Running <span id="statusRunning" class="num">-</span></span>
+                  <span class="status-pill">Error <span id="statusError" class="num">-</span></span>
+                  <span class="status-pill">Other <span id="statusOther" class="num">-</span></span>
+                </div>
+                <div>
+                  <span class="text-muted">Last Scan: <strong id="lastScanTime">-</strong></span>&nbsp;
+                  <span class="text-muted">Task: <strong id="lastTaskName">-</strong></span>&nbsp;
+                  <button id="refreshOverview" class="btn btn-xs btn-info"><i class="fa fa-refresh"></i> Refresh</button>
+                </div>
+              </div>
+              <div class="form-group">
+                <input id="taskFilterInput" class="form-control task-filter-input" placeholder="Filter latest task list by keyword...">
+              </div>
               <div class="table-responsive">
-                <table class="table no-margin">
+                <table id="latestTaskTable" class="table no-margin table-hover">
                   <thead>
                   <tr>
                     <th>Project</th>
@@ -124,15 +140,15 @@
                       <td>{{ task.last_scan_time }}</td>
                       <td>
                       {% if task.is_finished == 0 %}
-                      <span class="label label-danger">Error</span>
+                      <span class="label label-danger status-label">Error</span>
                       {% elif task.is_finished == -1 %}
-                      <span class="label label-danger">Error</span>
+                      <span class="label label-danger status-label">Error</span>
                       {% elif task.is_finished == 2 %}
-                      <span class="label label-warning">Running</span>
+                      <span class="label label-warning status-label">Running</span>
                       {% elif task.is_finished == 1 %}
-                      <span class="label label-success">Success</span>
+                      <span class="label label-success status-label">Success</span>
                       {% else %}
-                      <span class="label label-success">{{ task.is_finished }}</span>
+                      <span class="label label-success status-label">{{ task.is_finished }}</span>
                       {% endif %}
                       </td>
                       <td>

--- a/templates/dashboard/tasks/tasks_list.html
+++ b/templates/dashboard/tasks/tasks_list.html
@@ -7,10 +7,13 @@
           <div class="box">
             <div class="box-header">
               <h3 class="box-title">Tasks List</h3>
+              <div class="box-tools">
+                <input id="allTaskFilterInput" class="form-control input-sm" style="width: 240px;" placeholder="Search task table...">
+              </div>
             </div>
             <!-- /.box-header -->
             <div class="box-body table-responsive no-padding">
-              <table class="table table-hover">
+              <table id="allTaskTable" class="table table-hover">
                 <tbody><tr>
                   <th>ID</th>
                   <th>Project</th>
@@ -72,6 +75,14 @@
           $("#tasks").addClass("menu-open");
           $("#tasks").find("ul").find("li#task_list").addClass("active");
           $("#tasks").find("ul").css("display","block");
+
+          $("#allTaskFilterInput").on("input", function () {
+              var text = $(this).val().toLowerCase();
+              $("#allTaskTable tbody tr").each(function () {
+                  var rowText = $(this).text().toLowerCase();
+                  $(this).toggle(rowText.indexOf(text) > -1);
+              });
+          });
       });
 </script>
 

--- a/web/dashboard/urls.py
+++ b/web/dashboard/urls.py
@@ -45,6 +45,7 @@ urlpatterns = [
 
     # user
     path("userinfo", views.userinfo, name="userinfo"),
+    path("overview", views.overview, name="overview"),
 
     # interface
     # scan result

--- a/web/dashboard/views.py
+++ b/web/dashboard/views.py
@@ -8,6 +8,7 @@
 
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render, redirect
+from django.http import JsonResponse
 from web.index.models import ScanTask, Project
 from web.index.models import get_and_check_scantask_project_id
 
@@ -48,5 +49,46 @@ def userinfo(req):
 
     return render(req, 'dashboard/userinfo.html', data)
 
+
+@login_required
+def overview(req):
+    tasks = ScanTask.objects.all().order_by("-id")[:200]
+
+    status_count = {
+        "success": 0,
+        "running": 0,
+        "error": 0,
+        "other": 0,
+    }
+
+    latest_task = None
+    latest_scan_time = None
+
+    for task in tasks:
+        task_status = int(task.is_finished)
+        if task_status == 1:
+            status_count["success"] += 1
+        elif task_status == 2:
+            status_count["running"] += 1
+        elif task_status in [0, -1]:
+            status_count["error"] += 1
+        else:
+            status_count["other"] += 1
+
+        if latest_scan_time is None and task.last_scan_time:
+            latest_scan_time = str(task.last_scan_time)
+            latest_task = {
+                "id": task.id,
+                "task_name": task.task_name,
+                "target_path": task.target_path
+            }
+
+    return JsonResponse({
+        "status": "ok",
+        "count": len(tasks),
+        "task_status": status_count,
+        "latest_scan_time": latest_scan_time,
+        "latest_task": latest_task
+    })
 
 


### PR DESCRIPTION
### Motivation
- Improve dashboard usability by providing a lightweight overview API to enable async refresh without full page reloads.  
- Modernize the dashboard visual style and add quick navigation and theme controls to speed up common workflows.  
- Add client-side filtering and small UX improvements to make task discovery faster and more pleasant.

### Description
- Add a new authenticated JSON endpoint `overview` that aggregates recent task counts by status and returns the latest scan time and task metadata via `web/dashboard/views.py` and `web/dashboard/urls.py`.  
- Introduce a global quick-search input and a theme toggle in the dashboard header plus a new client script `static/js/dashboard-enhanced.js` to handle quick navigation, theme persistence, task filtering, and overview refresh.  
- Revamp dashboard home layout and interactions in `templates/dashboard/index.html` to include status pills, refresh button, and a latest-task filter; add a table search input to `templates/dashboard/tasks/tasks_list.html`.  
- Extend `static/css/default.css` with modernized styles for metric cards, toolbar/status pills, light/dark theme adaptations, and other layout tweaks.

### Testing
- Verified Python syntax for modified backend modules with `python -m compileall web/dashboard/views.py web/dashboard/urls.py`, and compilation completed successfully.  
- Confirmed the new JavaScript file `static/js/dashboard-enhanced.js` was added and templates reference it for client-side functionality.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e750e844d8832d84c3c6e422b10851)