### PR TITLE
Handle literal/string AST params safely, fix new/class and foreach return shapes, add tests

### DIFF
--- a/core/core_engine/php/parser.py
+++ b/core/core_engine/php/parser.py
@@ -326,6 +326,17 @@ def get_node_name(node):  # node为'node'中的元组
     return node
 
 
+def build_ast_param(param_expr):
+    """
+    将表达式构造成可继续回溯的参数节点。
+    仅将字符串变量名（以 $ 开头）转换为 php.Variable，
+    其余字面量字符串与 AST 节点保持原样，避免把常量字符串误当变量。
+    """
+    if isinstance(param_expr, str) and param_expr.startswith('$'):
+        return php.Variable(param_expr)
+    return param_expr
+
+
 def get_filename(node, file_path):  # 获取filename
     """
     获取
@@ -666,14 +677,12 @@ def new_class_back(param, nodes, vul_function=None, file_path=None, isback=None)
     :param nodes: 
     :return: 
     """
-    param = param.name
-    if hasattr(param, "name"):
-        # param_name = param.name
-        param_name = get_node_name(param)
-    else:
-        param_name = param
+    new_expr = param.name if hasattr(param, 'name') else param
 
-    param_params = param.params
+    if hasattr(new_expr, "name"):
+        param_name = get_node_name(new_expr)
+    else:
+        param_name = new_expr
 
     is_co = -1
     cp = param
@@ -698,7 +707,7 @@ def new_class_back(param, nodes, vul_function=None, file_path=None, isback=None)
 
         else:
             is_co = 3
-            cp = php.Variable(param)
+            cp = param
 
     return is_co, cp, expr_lineno
 
@@ -805,8 +814,8 @@ def parameters_back(param, nodes, function_params=None, lineno=0,
                 if isinstance(node.expr, php.ArrayOffset):
                     param = node.expr
                 else:
-                    param = php.Variable(param_expr)  # 每次找到一个污点的来源时，开始跟踪新污点，覆盖旧污点
-                    param_name = param_expr
+                    param = build_ast_param(param_expr)  # 每次找到一个污点的来源时，开始跟踪新污点，覆盖旧污点
+                    param_name = get_node_name(param)
 
             if param_name == param_node and isinstance(param_expr, php.TernaryOp):
                 terna1 = param_expr.iftrue
@@ -1309,7 +1318,7 @@ def parameters_back(param, nodes, function_params=None, lineno=0,
                 function_flag = 0
 
                 if is_co in [-1, 1, 2]:  # 目标确定直接返回
-                    return is_co, cp, expr_lineno, param_name, param
+                    return is_co, cp, expr_lineno
 
                 if _is_co == 3 and cp != param:
                     param = _cp
@@ -1353,8 +1362,8 @@ def parameters_back(param, nodes, function_params=None, lineno=0,
                     if isinstance(node.expr, php.ArrayOffset):
                         param = node.expr
                     else:
-                        param = php.Variable(param_expr)  # 每次找到一个污点的来源时，开始跟踪新污点，覆盖旧污点
-                        param_name = param_expr
+                        param = build_ast_param(param_expr)  # 每次找到一个污点的来源时，开始跟踪新污点，覆盖旧污点
+                        param_name = get_node_name(param)
 
                 elif isinstance(param_expr, list):
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -23,8 +23,11 @@ django.setup()
 
 from Kunlun_M.settings import PROJECT_DIRECTORY
 from core.core_engine.php.parser import anlysis_params
+from core.core_engine.php.parser import new_class_back
+from core.core_engine.php.parser import parameters_back
 from core.core_engine.php.parser import scan_parser
 from core.pretreatment import ast_object
+from phply import phpast as php
 
 files = [('.php', {'list': ["v_parser.php", "v.php"]})]
 ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', files)
@@ -52,3 +55,98 @@ def test_scan_parser():
 
 def test_anlysis_params():
     assert anlysis_params(param, target_projects2, lineno2)
+
+
+def test_new_class_back_handles_php_new_with_string_name():
+    """
+    回归测试：new_class_back 处理 php.New(name=str, ...) 时不应抛异常。
+    """
+    return_node = php.Return(php.Variable('$_GET'), lineno=3)
+    tostring_method = php.Method('__toString', [], [], [return_node], False, lineno=2)
+    class_node = php.Class('Demo', None, None, [], [], [tostring_method], lineno=1)
+
+    is_co, cp, expr_lineno = new_class_back(php.New('Demo', [], lineno=10), [class_node])
+
+    assert is_co == 1
+    assert cp.name == '$_GET'
+    assert isinstance(expr_lineno, int)
+
+
+def test_parameters_back_foreach_return_shape():
+    """
+    回归测试：Foreach 分支返回值固定为三元组，避免拆包异常。
+    """
+    foreach_var = php.ForeachVariable(php.Variable('$item'), False)
+    foreach_block = php.Block([], lineno=6)
+    foreach_node = php.Foreach(php.Variable('$arr'), None, foreach_var, foreach_block, lineno=5)
+
+    result = parameters_back(php.Variable('$x'), [foreach_node], lineno=10, file_path=target_projects2)
+
+    assert isinstance(result, tuple)
+    assert len(result) == 3
+
+
+def test_anlysis_params_new_class_tostring_integration():
+    """
+    集成回归：真实 PHP 文件中 $obj = new Demo() 时，
+    可沿 __toString() 回溯到 $_GET，判定为可控。
+    """
+    code = """<?php
+class Demo {
+    function __toString() {
+        return $_GET['name'];
+    }
+}
+$obj = new Demo();
+echo $obj;
+"""
+    temp_file = PROJECT_DIRECTORY + '/tests/vulnerabilities/v_new_class_runtime.php'
+    try:
+        with open(temp_file, 'w') as f:
+            f.write(code)
+
+        runtime_files = [('.php', {'list': ["v_new_class_runtime.php"]})]
+        ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', runtime_files)
+        ast_object.pre_ast_all(['php'])
+
+        is_co, cp, expr_lineno, chain = anlysis_params('$obj', temp_file, 8)
+
+        assert is_co == 1
+        assert cp.name == '$_GET'
+        assert isinstance(chain, list)
+    finally:
+        if os.path.exists(temp_file):
+            os.remove(temp_file)
+        ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', files)
+        ast_object.pre_ast_all(['php'])
+
+
+def test_anlysis_params_foreach_flow_integration():
+    """
+    集成回归：真实 foreach 数据流回溯不应出现返回值拆包异常。
+    """
+    code = """<?php
+$list = $_GET['items'];
+foreach ($list as $item) {
+    $x = $item;
+}
+print($x);
+"""
+    temp_file = PROJECT_DIRECTORY + '/tests/vulnerabilities/v_foreach_runtime.php'
+    try:
+        with open(temp_file, 'w') as f:
+            f.write(code)
+
+        runtime_files = [('.php', {'list': ["v_foreach_runtime.php"]})]
+        ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', runtime_files)
+        ast_object.pre_ast_all(['php'])
+
+        result = anlysis_params('$x', temp_file, 6)
+
+        assert isinstance(result, tuple)
+        assert len(result) == 4
+    finally:
+        if os.path.exists(temp_file):
+            os.remove(temp_file)
+        ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', files)
+        ast_object.pre_ast_all(['php'])


### PR DESCRIPTION
### Motivation

- Prevent incorrect wrapping of literal strings as `php.Variable` during AST backtracking which caused crashes for `new Class(...)` and foreach flows.

### Description

- Add helper `build_ast_param` that converts only string variable names (starting with `$`) into `php.Variable` and leaves other literals and AST nodes unchanged.
- Update `parameters_back` to use `build_ast_param` when creating new param tracking nodes and to derive `param_name` via `get_node_name` for robust name extraction.
- Make `new_class_back` resilient to `php.New(name=str, ...)` by avoiding inappropriate wrapping and by using `get_node_name` to compute the class/param name, and stop coercing `cp` into `php.Variable` erroneously.
- Update tests in `tests/test_parser.py` to cover `new_class_back`, `parameters_back` foreach behavior, and integration scenarios exercising `__toString()` backtracking and foreach dataflow.

### Testing

- Added unit tests `test_new_class_back_handles_php_new_with_string_name`, `test_parameters_back_foreach_return_shape`, and integration tests `test_anlysis_params_new_class_tostring_integration` and `test_anlysis_params_foreach_flow_integration` in `tests/test_parser.py` which exercise the new behaviors.
- Ran the test suite (pytest) and the new and existing tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e88b7a59cc832d96059b8faee940dc)