### PR TITLE
Add PHP AST fallback repair for parenthesized callable variables and tests

### DIFF
--- a/core/pretreatment.py
+++ b/core/pretreatment.py
@@ -91,6 +91,57 @@ class Pretreatment:
 
         asyncio.run(_run_pretreatment(scan_list))
 
+    @staticmethod
+    def _repair_php_code_for_parser(code_content):
+        """
+        尝试修复 phply 暂不支持的部分语法，避免整个文件 AST 预处理失败。
+        当前仅处理：($a)() 这类「括号包裹变量再调用」语法。
+        """
+        repaired_content = code_content
+        token_stream = lexer.clone()
+        token_stream.input(code_content)
+
+        tokens = []
+        while True:
+            token = token_stream.token()
+            if not token:
+                break
+            tokens.append(token)
+
+        # 仅在词法级别命中 ( VARIABLE ) ( 这种模式时进行修复，避免正则替换误伤字符串、注释等内容。
+        edits = []
+        token_count = len(tokens)
+        for index in range(token_count - 3):
+            token_lparen = tokens[index]
+            token_var = tokens[index + 1]
+            token_rparen = tokens[index + 2]
+            token_call_lparen = tokens[index + 3]
+
+            if not (token_lparen.type == 'LPAREN'
+                    and token_var.type == 'VARIABLE'
+                    and token_rparen.type == 'RPAREN'
+                    and token_call_lparen.type == 'LPAREN'):
+                continue
+
+            # 替换 "( $a )" 片段为 "$a"，保留后续调用参数括号。
+            start = token_lparen.lexpos
+            end = token_rparen.lexpos + len(token_rparen.value)
+            edits.append((start, end, token_var.value))
+
+        if not edits:
+            return repaired_content
+
+        # 按位置应用替换，避免下标偏移问题。
+        pieces = []
+        cursor = 0
+        for start, end, replacement in sorted(edits, key=lambda item: item[0]):
+            pieces.append(repaired_content[cursor:start])
+            pieces.append(replacement)
+            cursor = end
+        pieces.append(repaired_content[cursor:])
+
+        return ''.join(pieces)
+
     async def pre_ast(self):
 
         while not self.target_queue.empty():
@@ -126,8 +177,24 @@ class Pretreatment:
                         self.pre_result[filepath]['ast_nodes'] = all_nodes
 
                     except SyntaxError as e:
-                        logger.warning('[AST] [ERROR] parser {} SyntaxError'.format(filepath))
-                        continue
+                        if self.is_unprecom:
+                            logger.warning('[AST] [ERROR] parser {} SyntaxError'.format(filepath))
+                            continue
+
+                        repaired_code_content = self._repair_php_code_for_parser(code_content)
+
+                        if repaired_code_content == code_content:
+                            logger.warning('[AST] [ERROR] parser {} SyntaxError'.format(filepath))
+                            continue
+
+                        try:
+                            parser = make_parser()
+                            all_nodes = parser.parse(repaired_code_content, debug=False, lexer=lexer.clone(), tracking=True)
+                            logger.warning('[AST] [INFO] parser {} fallback with callable-variable repair'.format(filepath))
+                            self.pre_result[filepath]['ast_nodes'] = all_nodes
+                        except Exception:
+                            logger.warning('[AST] [ERROR] parser {} SyntaxError'.format(filepath))
+                            continue
 
                     except AssertionError as e:
                         logger.warning('[AST] [ERROR] parser {}: {}'.format(filepath, traceback.format_exc()))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -27,6 +27,7 @@ from core.core_engine.php.parser import new_class_back
 from core.core_engine.php.parser import parameters_back
 from core.core_engine.php.parser import scan_parser
 from core.pretreatment import ast_object
+from core.pretreatment import Pretreatment
 from phply import phpast as php
 
 files = [('.php', {'list': ["v_parser.php", "v.php"]})]
@@ -150,3 +151,44 @@ print($x);
             os.remove(temp_file)
         ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', files)
         ast_object.pre_ast_all(['php'])
+
+
+def test_pre_ast_php_parenthesized_callable_variable():
+    """
+    回归测试：($a)() 语法不应导致整个文件 AST 预处理失败。
+    """
+    code = """<?php
+$a = "phpinfo";
+($a)();
+"""
+    temp_file = PROJECT_DIRECTORY + '/tests/vulnerabilities/v_parenthesized_callable.php'
+    try:
+        with open(temp_file, 'w') as f:
+            f.write(code)
+
+        runtime_files = [('.php', {'list': ["v_parenthesized_callable.php"]})]
+        ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', runtime_files)
+        ast_object.pre_ast_all(['php'])
+
+        assert temp_file in ast_object.pre_result
+        assert ast_object.pre_result[temp_file]['ast_nodes']
+    finally:
+        if os.path.exists(temp_file):
+            os.remove(temp_file)
+        ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', files)
+        ast_object.pre_ast_all(['php'])
+
+
+def test_repair_php_code_for_parser_token_safe():
+    """
+    回归测试：仅修复真实 token 模式的 ($var)(...)，
+    不应误伤字符串中的同样文本。
+    """
+    code = """<?php
+$a = "phpinfo";
+($a)();
+$s = "($a)() should stay";
+"""
+    repaired = Pretreatment._repair_php_code_for_parser(code)
+    assert '$a();' in repaired
+    assert '"($a)() should stay"' in repaired


### PR DESCRIPTION
### Motivation

- The PHP AST preprocessor could fail on code like `($a)()` which phply does not handle, causing the whole file to be skipped.

### Description

- Add a static helper `Pretreatment._repair_php_code_for_parser` that tokenizes PHP source and rewrites parenthesized variable-call patterns `( $var )(...)` into `$var(...)` using `lexer.clone()` for token-safe edits.
- Integrate a fallback in `Pretreatment.pre_ast` to attempt repair on `SyntaxError` and reparse the repaired source, with logging when the fallback is used.
- Add tests `test_pre_ast_php_parenthesized_callable_variable` and `test_repair_php_code_for_parser_token_safe` to ensure the fallback prevents AST failures and does not alter similar text inside strings.
- Export `Pretreatment` in the test module to exercise the new static method.

### Testing

- Ran the updated parser tests including `test_pre_ast_php_parenthesized_callable_variable`, which verifies `ast_nodes` are produced for a file containing `($a)();`, and it passed.
- Ran `test_repair_php_code_for_parser_token_safe`, which verifies the repair is token-aware and preserves strings, and it passed.
- Ran the existing `tests/test_parser.py` suite to ensure no regressions, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e891c717d0832dbfd174a6a28e80b8)