### PR TITLE
fix: trace include/require assignments in PHP parser (fix #236)

### DIFF
--- a/core/core_engine/php/parser.py
+++ b/core/core_engine/php/parser.py
@@ -757,6 +757,16 @@ def parameters_back(param, nodes, function_params=None, lineno=0,
 
         is_co, cp = is_controllable(param)
 
+    if isinstance(param, php.Include) or isinstance(param, php.Require):
+        # include/require 也可能作为赋值右值或 return 值参与数据流，继续回溯其参数表达式
+        logger.debug("[AST] AST analysis for Include/Require in line {}".format(param.lineno))
+        param = param.expr
+        if hasattr(param, "name"):
+            param_name = get_node_name(param)
+        else:
+            param_name = param
+        is_co, cp = is_controllable(param)
+
     if isinstance(param, php.New) or (
                 hasattr(param, "name") and isinstance(param.name, php.New)):  # 当污点为新建类事，进入类中tostring函数分析
         logger.debug("[AST] AST analysis for New Class {} in line {}".format(param.name, param.lineno))
@@ -913,6 +923,23 @@ def parameters_back(param, nodes, function_params=None, lineno=0,
                 # 将右值置为methodcall
                 param = node.expr
                 is_co = 3
+
+            if param_name == param_node and (isinstance(node.expr, php.Include) or isinstance(node.expr, php.Require)):
+                logger.debug("[AST] Find {} from Include/Require in line {}.".format(param_name, node.lineno))
+
+                file_path = os.path.normpath(file_path)
+                code = "{}={}".format(param_name, node.expr)
+                scan_chain.append(('Include', code, file_path, node.lineno))
+
+                param = node.expr.expr
+                if hasattr(param, "name"):
+                    param_name = get_node_name(param)
+                else:
+                    param_name = param
+                is_co, cp = is_controllable(param)
+
+                if is_co in [-1, 1, 2]:
+                    return is_co, cp, expr_lineno
 
             if param_name == param_node and isinstance(param_expr, list):
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -192,3 +192,49 @@ $s = "($a)() should stay";
     repaired = Pretreatment._repair_php_code_for_parser(code)
     assert '$a();' in repaired
     assert '"($a)() should stay"' in repaired
+
+
+def test_anlysis_params_require_assignment_in_private_method():
+    """
+    回归测试：类私有方法中 `$var = require($file)` 的赋值链应可继续回溯。
+    """
+    code = """<?php
+class LangLoader {
+    private function getLangFileFullPath($local, $module) {
+        return $local;
+    }
+
+    private function getArrayFromPhp($file) {
+        $array = require($file);
+        return $array;
+    }
+
+    public function getPhpLangArrayByModule($local, $module) {
+        return $this->getArrayFromPhp($this->getLangFileFullPath($local, $module));
+    }
+}
+
+$loader = new LangLoader();
+$input = $_GET['lang'];
+$ret = $loader->getPhpLangArrayByModule($input, 'common');
+print($ret);
+"""
+    temp_file = PROJECT_DIRECTORY + '/tests/vulnerabilities/v_require_assignment_runtime.php'
+    try:
+        with open(temp_file, 'w') as f:
+            f.write(code)
+
+        runtime_files = [('.php', {'list': ["v_require_assignment_runtime.php"]})]
+        ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', runtime_files)
+        ast_object.pre_ast_all(['php'])
+
+        is_co, cp, expr_lineno, chain = anlysis_params('$ret', temp_file, 20)
+
+        assert is_co == 1
+        assert cp.name == '$_GET'
+        assert isinstance(chain, list)
+    finally:
+        if os.path.exists(temp_file):
+            os.remove(temp_file)
+        ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', files)
+        ast_object.pre_ast_all(['php'])


### PR DESCRIPTION
### Motivation
- Fix dataflow/backtracing break when PHP `include`/`require` appear as assignment/right-hand expressions so taint can propagate through `$var = require($file)` patterns.
- Address the specific case where the include/require occurs inside private method call chains which previously stopped the backtrace and caused false negatives (issue #236).

### Description
- Add handling for `php.Include` and `php.Require` in `parameters_back` to normalize the node to its inner expression (`param.expr`) and continue controllability checks.
- Add an assignment branch that recognizes `node.expr` being `Include`/`Require`, records the event to `scan_chain` and continues backtracing from the include/require argument.
- Record the include/require assignment in the `scan_chain` to preserve the dataflow trail for diagnostics and reporting.
- Add a regression test `test_anlysis_params_require_assignment_in_private_method` in `tests/test_parser.py` that reproduces the private-method + `require` assignment scenario and asserts the taint reaches `$_GET`.
- Files changed: `core/core_engine/php/parser.py` and `tests/test_parser.py`.

### Testing
- Ran the new regression test with `pytest -q tests/test_parser.py::test_anlysis_params_require_assignment_in_private_method` and it passed.
- Ran the pair `pytest -q tests/test_parser.py::test_scan_parser tests/test_parser.py::test_anlysis_params_require_assignment_in_private_method` and both tests passed.
- No other automated tests were modified; the targeted tests succeeded (both passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e89be3c9e0832da6edd6bed7fdd368)