### PR TITLE
Avoid false positives in dynamic class variable detection and add unit tests

### DIFF
--- a/core/plugins/phpunserializechain/main.py
+++ b/core/plugins/phpunserializechain/main.py
@@ -641,20 +641,21 @@ class PhpUnSerChain(BasePluginClass):
         :param var_name:
         :return:
         """
-        # 检查是否为函数调用
+        # MethodCall-/FunctionCall-场景仅关注调用目标，参数中包含->不应命中动态方法调用
         if var_name.startswith('FunctionCall-') or var_name.startswith('MethodCall-'):
-            var_name_list = re.split("[()]", var_name)
-            var_name = ",".join(var_name_list)
+            var_name = var_name.split('-', 1)[1]
 
         for var_node in var_name.split(','):
+            call_target = var_node.split('(', 1)[0]
 
-            if '->' in var_node:
-                var_node_parts = var_node.split('->')
+            # 仅处理 $this->a->b 一类动态类变量，普通 $this->method(...) 不应进入该分支
+            if call_target.count('->') < 2:
+                continue
 
-                var_node_left = '->'.join(var_node_parts[:-1])
-                var_node_right = var_node_parts[-1]
+            var_node_parts = call_target.split('->')
+            var_node_left = '->'.join(var_node_parts[:-1])
 
-                return self.check_param_controllable(var_node_left, now_node)
+            return self.check_param_controllable(var_node_left, now_node)
 
         return False
 

--- a/tests/test_phpunserializechain_dynamic_call.py
+++ b/tests/test_phpunserializechain_dynamic_call.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+import os
+
+# for django
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'Kunlun_M.settings')
+
+import django
+
+django.setup()
+
+from core.plugins.phpunserializechain.main import PhpUnSerChain
+
+
+class DummyNode:
+    id = 1
+    node_locate = 'File-0.Class-A.Method-x'
+
+
+def _build_plugin(controllable_result=True):
+    plugin = object.__new__(PhpUnSerChain)
+    called = []
+
+    def _fake_check_param_controllable(param_name, now_node):
+        called.append((param_name, now_node))
+        return controllable_result
+
+    plugin.check_param_controllable = _fake_check_param_controllable
+    return plugin, called
+
+
+def test_normal_method_call_with_object_param_should_not_be_dynamic_dispatch():
+    plugin, called = _build_plugin(controllable_result=True)
+
+    result = plugin.check_dynamic_class_var_exist(
+        "MethodCall-Variable-$this->normalizeFormat('Variable-$format->name',)",
+        DummyNode(),
+    )
+
+    assert result is False
+    assert called == []
+
+
+def test_dynamic_chain_call_target_should_trigger_controllability_check():
+    plugin, called = _build_plugin(controllable_result=True)
+
+    result = plugin.check_dynamic_class_var_exist(
+        "MethodCall-Variable-$this->formatter->normalizeFormat('Variable-$format',)",
+        DummyNode(),
+    )
+
+    assert result is True
+    assert len(called) == 1
+    assert called[0][0] == 'Variable-$this->formatter'
+
+
+def test_dynamic_chain_call_target_returns_false_when_not_controllable():
+    plugin, called = _build_plugin(controllable_result=False)
+
+    result = plugin.check_dynamic_class_var_exist(
+        "MethodCall-Variable-$this->formatter->normalizeFormat('Variable-$format',)",
+        DummyNode(),
+    )
+
+    assert result is False
+    assert len(called) == 1
+    assert called[0][0] == 'Variable-$this->formatter'
+
+
+def test_function_call_with_arrow_inside_arguments_should_not_be_dynamic_dispatch():
+    plugin, called = _build_plugin(controllable_result=True)
+
+    result = plugin.check_dynamic_class_var_exist(
+        "FunctionCall-format('Variable-$this->formatter->name')",
+        DummyNode(),
+    )
+
+    assert result is False
+    assert called == []
+
+
+def test_non_call_dynamic_property_chain_still_supported():
+    plugin, called = _build_plugin(controllable_result=True)
+
+    result = plugin.check_dynamic_class_var_exist('Variable-$this->a->b', DummyNode())
+
+    assert result is True
+    assert len(called) == 1
+    assert called[0][0] == 'Variable-$this->a'


### PR DESCRIPTION
### Motivation

- Prevent false positives where `MethodCall-`/`FunctionCall-` argument strings that contain `->` are mistaken for dynamic property chains.
- Make parsing of call expressions more robust by explicitly isolating the call target and ignoring argument content.

### Description

- Update `check_dynamic_class_var_exist` to strip the `MethodCall-`/`FunctionCall-` prefix using `var_name.split('-', 1)[1]` and to extract the call target before the first `(` with `split('(', 1)[0]`.
- Only consider a dynamic class property chain when the call target contains at least two `->` segments (`call_target.count('->') >= 2`) and then call `check_param_controllable` on the left-side chain part.
- Remove the previous regex/parenthesis-based parsing and simplify the logic for clarity and correctness.
- Add `tests/test_phpunserializechain_dynamic_call.py` with unit tests that mock `check_param_controllable` and cover method calls, function calls with `->` in arguments, and non-call dynamic property chains.

### Testing

- Added and ran the unit tests in `tests/test_phpunserializechain_dynamic_call.py` using the project's test runner; all tests passed.
- Existing behavior for non-call dynamic property chains was validated by the new tests and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9d812535c832d95a699b57dad9afe)