### PR TITLE
fix(php): handle assignment expressions inside echo sink

### DIFF
--- a/core/core_engine/php/parser.py
+++ b/core/core_engine/php/parser.py
@@ -1705,6 +1705,56 @@ def anlysis_function(node, back_node, vul_function, function_params, vul_lineno,
                     if isinstance(param, php.ArrayOffset):
                         analysis_arrayoffset_node(param, vul_function, vul_lineno)
 
+                    if isinstance(param, php.Assignment):
+                        if isinstance(param.node, php.Variable):
+                            analysis_variable_node(param.node, back_node, vul_function, vul_lineno, function_params,
+                                                   file_path=file_path)
+
+                        if isinstance(param.expr, php.FunctionCall) or isinstance(param.expr, php.MethodCall) or isinstance(
+                                param.expr, php.StaticMethodCall):
+                            analysis_functioncall_node(param.expr, back_node, vul_function, vul_lineno, function_params,
+                                                       file_path=file_path)
+
+                        if isinstance(param.expr, php.Variable):
+                            analysis_variable_node(param.expr, back_node, vul_function, vul_lineno, function_params,
+                                                   file_path=file_path)
+
+                        if isinstance(param.expr, php.BinaryOp):
+                            analysis_binaryop_node(param.expr, back_node, vul_function, vul_lineno, function_params,
+                                                   file_path=file_path)
+
+                        if isinstance(param.expr, php.ArrayOffset):
+                            analysis_arrayoffset_node(param.expr, vul_function, vul_lineno)
+
+                        if isinstance(param.expr, php.TernaryOp):
+                            analysis_ternaryop_node(param.expr, back_node, vul_function, vul_lineno, function_params,
+                                                    file_path=file_path)
+
+                    if isinstance(param, php.AssignOp):
+                        if isinstance(param.left, php.Variable):
+                            analysis_variable_node(param.left, back_node, vul_function, vul_lineno, function_params,
+                                                   file_path=file_path)
+
+                        if isinstance(param.right, php.FunctionCall) or isinstance(param.right, php.MethodCall) or isinstance(
+                                param.right, php.StaticMethodCall):
+                            analysis_functioncall_node(param.right, back_node, vul_function, vul_lineno, function_params,
+                                                       file_path=file_path)
+
+                        if isinstance(param.right, php.Variable):
+                            analysis_variable_node(param.right, back_node, vul_function, vul_lineno, function_params,
+                                                   file_path=file_path)
+
+                        if isinstance(param.right, php.BinaryOp):
+                            analysis_binaryop_node(param.right, back_node, vul_function, vul_lineno, function_params,
+                                                   file_path=file_path)
+
+                        if isinstance(param.right, php.ArrayOffset):
+                            analysis_arrayoffset_node(param.right, vul_function, vul_lineno)
+
+                        if isinstance(param.right, php.TernaryOp):
+                            analysis_ternaryop_node(param.right, back_node, vul_function, vul_lineno, function_params,
+                                                    file_path=file_path)
+
                     if param_node_typename in SPECIAL_FUNCTIONCALL_LIST:
                         analysis_special_functioncall_node(param, back_node, vul_function, vul_lineno, function_params,
                                                            file_path=file_path)
@@ -2060,6 +2110,52 @@ def analysis_echo_print(node, back_node, vul_function, vul_lineno, function_para
                 if isinstance(k_node, php.TernaryOp) and vul_function == 'echo':
                     analysis_ternaryop_node(k_node, back_node, vul_function, vul_lineno, function_params,
                                             file_path=file_path)
+
+                if isinstance(k_node, php.Assignment) and vul_function == 'echo':
+                    analysis_variable_node(k_node.node, back_node, vul_function, vul_lineno, function_params,
+                                           file_path=file_path)
+                    if isinstance(k_node.expr, php.FunctionCall) or isinstance(k_node.expr, php.MethodCall) or isinstance(
+                            k_node.expr, php.StaticMethodCall):
+                        analysis_functioncall_node(k_node.expr, back_node, vul_function, vul_lineno, function_params,
+                                                   file_path=file_path)
+
+                    if isinstance(k_node.expr, php.Variable):
+                        analysis_variable_node(k_node.expr, back_node, vul_function, vul_lineno, function_params,
+                                               file_path=file_path)
+
+                    if isinstance(k_node.expr, php.BinaryOp):
+                        analysis_binaryop_node(k_node.expr, back_node, vul_function, vul_lineno, function_params,
+                                               file_path=file_path)
+
+                    if isinstance(k_node.expr, php.ArrayOffset):
+                        analysis_arrayoffset_node(k_node.expr, vul_function, vul_lineno)
+
+                    if isinstance(k_node.expr, php.TernaryOp):
+                        analysis_ternaryop_node(k_node.expr, back_node, vul_function, vul_lineno, function_params,
+                                                file_path=file_path)
+
+                if isinstance(k_node, php.AssignOp) and vul_function == 'echo':
+                    analysis_variable_node(k_node.left, back_node, vul_function, vul_lineno, function_params,
+                                           file_path=file_path)
+                    if isinstance(k_node.right, php.FunctionCall) or isinstance(k_node.right, php.MethodCall) or isinstance(
+                            k_node.right, php.StaticMethodCall):
+                        analysis_functioncall_node(k_node.right, back_node, vul_function, vul_lineno, function_params,
+                                                   file_path=file_path)
+
+                    if isinstance(k_node.right, php.Variable):
+                        analysis_variable_node(k_node.right, back_node, vul_function, vul_lineno, function_params,
+                                               file_path=file_path)
+
+                    if isinstance(k_node.right, php.BinaryOp):
+                        analysis_binaryop_node(k_node.right, back_node, vul_function, vul_lineno, function_params,
+                                               file_path=file_path)
+
+                    if isinstance(k_node.right, php.ArrayOffset):
+                        analysis_arrayoffset_node(k_node.right, vul_function, vul_lineno)
+
+                    if isinstance(k_node.right, php.TernaryOp):
+                        analysis_ternaryop_node(k_node.right, back_node, vul_function, vul_lineno, function_params,
+                                                file_path=file_path)
 
                 if param_node_typename in SPECIAL_FUNCTIONCALL_LIST:
                     analysis_special_functioncall_node(k_node, back_node, vul_function, vul_lineno, function_params,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -222,6 +222,34 @@ define(__NAMESPACE__ . "1", __NAMESPACE__ . "2");
         ast_object.pre_ast_all(['php'])
 
 
+def test_scan_parser_echo_assignment_with_user_input():
+    """
+    回归测试：`echo $a = $_GET['a'];` 应识别为 echo sink 且可追踪到可控来源。
+    """
+    code = """<?php
+echo $a = $_GET['a'];
+"""
+    temp_file = PROJECT_DIRECTORY + '/tests/vulnerabilities/v_echo_assignment_runtime.php'
+    try:
+        with open(temp_file, 'w') as f:
+            f.write(code)
+
+        runtime_files = [('.php', {'list': ["v_echo_assignment_runtime.php"]})]
+        ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', runtime_files)
+        ast_object.pre_ast_all(['php'])
+
+        result = scan_parser(['echo'], 2, temp_file)
+
+        assert isinstance(result, list)
+        assert result
+        assert result[0].get('source') is not None
+    finally:
+        if os.path.exists(temp_file):
+            os.remove(temp_file)
+        ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', files)
+        ast_object.pre_ast_all(['php'])
+
+
 def test_anlysis_params_require_assignment_in_private_method():
     """
     回归测试：类私有方法中 `$var = require($file)` 的赋值链应可继续回溯。


### PR DESCRIPTION
### Motivation
- `echo` and other special AST nodes could contain `Assignment`/`AssignOp` expressions as direct children, which were not analyzed for controllable input and caused patterns like `echo $a = $_GET['a'];` to be missed (Issue #210). 
- The goal is to ensure assignment-style parameters inside special-function nodes are analyzed both for the left-hand variable and the right-hand expression so user-controlled sources are detected.

### Description
- Extended `anlysis_function` to handle `php.Assignment` and `php.AssignOp` parameter types by analyzing their left/right parts (including `Variable`, `FunctionCall`, `BinaryOp`, `ArrayOffset`, `TernaryOp`).
- Added equivalent handling inside `analysis_echo_print` so `Echo` nodes with `Assignment`/`AssignOp` children are processed correctly.
- Added regression test `test_scan_parser_echo_assignment_with_user_input` in `tests/test_parser.py` which creates `v_echo_assignment_runtime.php` containing `echo $a = $_GET['a'];` and asserts `scan_parser(['echo'], 2, ...)` returns a controllable source.
- Modified `core/core_engine/php/parser.py` and `tests/test_parser.py` to implement the above logic and test coverage.

### Testing
- Ran `pytest -q tests/test_parser.py -k "echo_assignment_with_user_input or test_scan_parser"` and the targeted tests passed.
- Ran the full parser test file with `pytest -q tests/test_parser.py` and all tests passed (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e9962b68832d8d85ce8a522d3076)