### PR TITLE
fix(php): backtrack foreach values from function-call sources

### DIFF
--- a/core/core_engine/php/parser.py
+++ b/core/core_engine/php/parser.py
@@ -1335,7 +1335,7 @@ def parameters_back(param, nodes, function_params=None, lineno=0,
                 if isinstance(node.expr, php.ArrayOffset):
                     param_expr = node.expr.node
                 else:
-                    param_expr = node.expr.name
+                    param_expr = node.expr
                 expr_lineno = node.lineno
                 # 找到变量的来源，开始继续分析变量的赋值表达式是否可控
                 logger.debug(
@@ -1344,17 +1344,34 @@ def parameters_back(param, nodes, function_params=None, lineno=0,
                 file_path = os.path.normpath(file_path)
                 code = "foreach ({} as {})".format(param_expr, param_name)
                 scan_chain.append(('Foreach', code, file_path, node.lineno))
-                param = php.Variable(param_expr)  # 每次找到一个污点的来源时，开始跟踪新污点，覆盖旧污点
-                param_name = param_expr
+                param = build_ast_param(param_expr)  # 每次找到一个污点的来源时，开始跟踪新污点，覆盖旧污点
+                param_name = get_node_name(param) if hasattr(param, 'name') else param
             else:
                 foreach_nodes = node.node.nodes
                 foreach_node_lineno = node.node.lineno
                 logger.debug("[AST] Find foreach, start ast in foreach")
 
-                is_co, cp, expr_lineno = parameters_back(param, foreach_nodes, function_params, foreach_node_lineno,
+                is_co, cp, expr_lineno = parameters_back(param, foreach_nodes, function_params, lineno,
                                                          function_flag=1, vul_function=vul_function, file_path=file_path,
                                                          isback=isback, parent_node=node)
                 function_flag = 0
+                if is_co == 3:
+                    _is_co = is_co
+                    _cp = cp
+                    if hasattr(cp, 'name') and cp.name == node.valvar.name.name:
+                        if isinstance(node.expr, php.ArrayOffset):
+                            param_expr = node.expr.node
+                        else:
+                            param_expr = node.expr
+
+                        file_path = os.path.normpath(file_path)
+                        code = "foreach ({} as {})".format(param_expr, cp.name)
+                        scan_chain.append(('Foreach', code, file_path, node.lineno))
+
+                        param = build_ast_param(param_expr)
+                        param_name = get_node_name(param) if hasattr(param, 'name') else param
+                        _is_co = 0
+                        _cp = param
 
                 if is_co in [-1, 1, 2]:  # 目标确定直接返回
                     return is_co, cp, expr_lineno

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -153,6 +153,40 @@ print($x);
         ast_object.pre_ast_all(['php'])
 
 
+def test_anlysis_params_foreach_from_functioncall_source():
+    """
+    回归测试：foreach 源为函数调用时，应继续沿函数返回值回溯污点来源。
+    """
+    code = """<?php
+function getItems() {
+    return $_GET['items'];
+}
+foreach (getItems() as $item) {
+    $x = $item;
+}
+print($x);
+"""
+    temp_file = PROJECT_DIRECTORY + '/tests/vulnerabilities/v_foreach_function_source_runtime.php'
+    try:
+        with open(temp_file, 'w') as f:
+            f.write(code)
+
+        runtime_files = [('.php', {'list': ["v_foreach_function_source_runtime.php"]})]
+        ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', runtime_files)
+        ast_object.pre_ast_all(['php'])
+
+        is_co, cp, expr_lineno, chain = anlysis_params('$x', temp_file, 8)
+
+        assert is_co == 1
+        assert cp.name == '$_GET'
+        assert isinstance(chain, list)
+    finally:
+        if os.path.exists(temp_file):
+            os.remove(temp_file)
+        ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', files)
+        ast_object.pre_ast_all(['php'])
+
+
 def test_pre_ast_php_parenthesized_callable_variable():
     """
     回归测试：($a)() 语法不应导致整个文件 AST 预处理失败。


### PR DESCRIPTION
### Motivation
- The PHP taint backtracker failed to follow `foreach` sources that are function calls (e.g. `foreach (getItems() as $item)`), so assignments inside the loop (like `$x = $item`) could not be traced back to the function return (such as `$_GET`).
- This caused false negatives for flows where the iterable is produced by a function returning user-controlled data.

### Description
- Preserve the original `foreach` source AST node instead of forcing `.name` when the loop expression is not a plain variable, by using `build_ast_param` so the analyzer can continue backtracking through function-call return values (file: `core/core_engine/php/parser.py`).
- When analysis of the `foreach` body yields an unresolved taint (`is_co == 3`), propagate that taint outwards and check whether it corresponds to the loop value (`valvar`) so we can map the inner assignment back to the loop source and resume backtracking (file: `core/core_engine/php/parser.py`).
- Ensure the recursive call into the `foreach` body uses the outer vulnerability `lineno` so assignments inside the loop are not skipped by line-range checks (file: `core/core_engine/php/parser.py`).
- Add a regression test `test_anlysis_params_foreach_from_functioncall_source` that covers `foreach` where the source is a function returning `$_GET`, verifying `anlysis_params` successfully reports the user-controlled source (file: `tests/test_parser.py`).

### Testing
- Ran the new regression test with `pytest -q tests/test_parser.py::test_anlysis_params_foreach_from_functioncall_source`, which passed.
- Ran `pytest -q tests/test_parser.py` to validate parser-related tests, which passed (`13 passed`).
- Ran the full test suite with `pytest -q`, which passed (`59 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ec019e78832da4ddaf9143f57f79)