### PR TITLE
fix(php): recognize controllable tamper function calls used in sink arguments

### DIFF
--- a/core/core_engine/php/parser.py
+++ b/core/core_engine/php/parser.py
@@ -1922,6 +1922,14 @@ def analysis_functioncall_node(node, back_node, vul_function, vul_lineno, functi
         logger.info("[AST] Function {} is repair func. fail control back.".format(function_name))
         return False
 
+    # 如果危险函数参数本身是可控函数调用（例如 system(input('get.id'))），
+    # 直接按可控处理，避免继续回溯 input 的字面量参数导致漏报。
+    is_co, cp = is_controllable(function_name)
+    if is_co == 1:
+        expr_lineno = node.lineno
+        set_scan_results(is_co, cp, expr_lineno, vul_function, node, vul_lineno)
+        return True
+
     for param in params:
         param = php.Variable(param)
         param_lineno = node.lineno


### PR DESCRIPTION
### Motivation
- Fix a false-negative in PHP taint analysis where a sink argument that is itself a function call (e.g. `system(input('get.id'))`) was not treated as controllable when `input` is declared controllable by tamper rules.

### Description
- Add a pre-check in `analysis_functioncall_node` to call `is_controllable(function_name)` and, if controllable, call `set_scan_results` with the sink node and return early so the call is recorded as controllable instead of continuing literal-argument backtracing.

### Testing
- Ran `python -m py_compile core/core_engine/php/parser.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaebb0dae0832d81aef2c4f6a9a58f)