### PR TITLE
Do not treat .inc files as PHP; update language rules and add tests

### DIFF
--- a/Kunlun_M/const.py
+++ b/Kunlun_M/const.py
@@ -59,7 +59,7 @@ fpc_loose = '(?:(\A|\s|\\b)[f])({fpc})?\\b'.format(fpc=fpc)
 fav = '\$([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)'
 
 ext_dict = {
-    "php": ['.php', '.php3', '.php4', '.php5', '.php7', '.pht', '.phs', '.phtml', '.inc'],
+    "php": ['.php', '.php3', '.php4', '.php5', '.php7', '.pht', '.phs', '.phtml'],
     "solidity": ['.sol'],
     "javascript": ['.js'],
     "chromeext": ['.crx'],

--- a/rules/languages.xml
+++ b/rules/languages.xml
@@ -12,7 +12,6 @@
         <extension value=".pht"/>
         <extension value=".phs"/>
         <extension value=".phtml"/>
-        <extension value=".inc"/>
     </language>
     <language name="Java" chiefly="True">
         <extension value=".java"/>

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -123,3 +123,19 @@ def test_count_total_num():
 
 def test_cloc():
     assert Detection(EXAMPLES_PATH, '.').cloc()
+
+
+def test_language_detection_does_not_treat_inc_as_php():
+    files = [
+        ('.inc', {'count': 1, 'list': ['/example.inc']}),
+    ]
+    detection = Detection(EXAMPLES_PATH, files)
+    assert detection.language == []
+
+
+def test_language_detection_still_treats_php_as_php():
+    files = [
+        ('.php', {'count': 1, 'list': ['/example.php']}),
+    ]
+    detection = Detection(EXAMPLES_PATH, files)
+    assert detection.language == ['php']


### PR DESCRIPTION
### Motivation
- Prevent .inc files from being classified as PHP to avoid incorrect language detection and false positives during analysis.

### Description
- Remove `'.inc'` from the PHP extension list in `Kunlun_M/const.py` so the core extension map no longer treats `.inc` as PHP.
- Remove the `.inc` `<extension>` entry from `rules/languages.xml` to keep the XML language rules consistent with the code change.
- Add unit tests in `tests/test_detection.py` to assert that `.inc` files are not detected as PHP and that `.php` files are still detected as PHP.

### Testing
- Ran the test suite for detection tests with `pytest tests/test_detection.py`, and the new tests for `.inc` and `.php` detection passed.}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaef0f8800832dbe82af30cabecee1)