### PR TITLE
fix: handle PHP7 null coalescing operator in AST pretreatment (fix #130)

### DIFF
--- a/core/pretreatment.py
+++ b/core/pretreatment.py
@@ -121,7 +121,9 @@ class Pretreatment:
     def _repair_php_code_for_parser(code_content):
         """
         尝试修复 phply 暂不支持的部分语法，避免整个文件 AST 预处理失败。
-        当前仅处理：($a)() 这类「括号包裹变量再调用」语法。
+        当前处理：
+        1. ($a)() 这类「括号包裹变量再调用」语法；
+        2. PHP7 null coalescing（??）语法，降级为 ?: 以便 phply 继续解析。
         """
         repaired_content = code_content
         token_stream = lexer.clone()
@@ -134,9 +136,22 @@ class Pretreatment:
                 break
             tokens.append(token)
 
-        # 仅在词法级别命中 ( VARIABLE ) ( 这种模式时进行修复，避免正则替换误伤字符串、注释等内容。
+        # 仅在词法级别命中特定模式时进行修复，避免正则替换误伤字符串、注释等内容。
         edits = []
         token_count = len(tokens)
+
+        # 修复 phply 不支持的 null coalescing 运算符 ??。
+        # 这里仅做语法层面的降级（?? -> ?:），目标是让 AST 预处理不中断。
+        for index in range(token_count - 1):
+            token_q1 = tokens[index]
+            token_q2 = tokens[index + 1]
+
+            if token_q1.type == 'QUESTION' and token_q2.type == 'QUESTION':
+                start = token_q1.lexpos
+                end = token_q2.lexpos + len(token_q2.value)
+                edits.append((start, end, '?:'))
+
+        # 修复 ( VARIABLE ) ( 语法模式。
         for index in range(token_count - 3):
             token_lparen = tokens[index]
             token_var = tokens[index + 1]
@@ -161,6 +176,9 @@ class Pretreatment:
         pieces = []
         cursor = 0
         for start, end, replacement in sorted(edits, key=lambda item: item[0]):
+            if start < cursor:
+                # 重叠编辑（理论上不应出现），跳过后续冲突项。
+                continue
             pieces.append(repaired_content[cursor:start])
             pieces.append(replacement)
             cursor = end

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -228,6 +228,44 @@ $s = "($a)() should stay";
     assert '"($a)() should stay"' in repaired
 
 
+def test_repair_php_code_for_parser_null_coalesce():
+    """
+    回归测试：PHP7 null coalescing（??）语法应被降级修复为可解析形式。
+    """
+    code = """<?php
+$a = $_GET["name"] ?? "guest";
+"""
+    repaired = Pretreatment._repair_php_code_for_parser(code)
+    assert '??' not in repaired
+    assert '?:' in repaired
+
+
+def test_pre_ast_php_null_coalesce_operator():
+    """
+    回归测试：包含 ?? 的 PHP 文件不应导致整个文件 AST 预处理失败（Issue #130）。
+    """
+    code = """<?php
+$name = $_GET['name'] ?? 'guest';
+echo $name;
+"""
+    temp_file = PROJECT_DIRECTORY + '/tests/vulnerabilities/v_php7_null_coalesce.php'
+    try:
+        with open(temp_file, 'w') as f:
+            f.write(code)
+
+        runtime_files = [('.php', {'list': ["v_php7_null_coalesce.php"]})]
+        ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', runtime_files)
+        ast_object.pre_ast_all(['php'])
+
+        assert temp_file in ast_object.pre_result
+        assert ast_object.pre_result[temp_file]['ast_nodes']
+    finally:
+        if os.path.exists(temp_file):
+            os.remove(temp_file)
+        ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', files)
+        ast_object.pre_ast_all(['php'])
+
+
 def test_pre_ast_define_namespace_concat_key():
     """
     回归测试：define(__NAMESPACE__ . "X", ...) 不应在预处理阶段触发


### PR DESCRIPTION
### Motivation
- Prevent files containing PHP7 null coalescing operator (`??`) from causing AST pre-processing to fail by providing a safe fallback for the legacy `phply` parser.

### Description
- Extend `Pretreatment._repair_php_code_for_parser` in `core/pretreatment.py` to detect token-level `??` sequences and replace them with `?:` so `phply` can parse the file.
- Preserve and reuse the existing callable-variable repair for `($a)()` invocations and apply all edits at the lexer/token level to avoid altering strings or comments.
- Add a guard to skip overlapping edits when applying multiple token replacements to avoid corrupting the reconstructed source.
- Add regression tests in `tests/test_parser.py` covering the repair behavior (`test_repair_php_code_for_parser_null_coalesce`) and full AST pretreatment flow for a file containing `??` (`test_pre_ast_php_null_coalesce_operator`).

### Testing
- Ran `pytest -q tests/test_parser.py -k "null_coalesce or repair_php_code_for_parser_token_safe"` and the targeted tests passed with `3 passed, 12 deselected` (with unrelated DeprecationWarnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb195461c4832da8e27e7821c3e940)