### PR TITLE
fix(phpunserializechain): preserve conditional function-call nodes in CodeDB ordering

### DIFF
--- a/core/plugins/phpunserializechain/dataflowgenerate.py
+++ b/core/plugins/phpunserializechain/dataflowgenerate.py
@@ -468,7 +468,7 @@ class DataflowGenerate:
                     if node_typename in ['While', 'DoWhile']:
 
                         # 处理expr op
-                        node_id, new_node = self.deep_obj_address_generate(node.expr, new_locate, -1)
+                        node_id, new_node = self.deep_obj_address_generate(node.expr, new_locate, now_sort)
 
                         if node_id:
                             node_sink = '&{}'.format(node_id)
@@ -479,7 +479,7 @@ class DataflowGenerate:
 
                     elif node_typename == 'If':
                         # 处理expr op
-                        node_id, new_node = self.deep_obj_address_generate(node.expr, new_locate, -1)
+                        node_id, new_node = self.deep_obj_address_generate(node.expr, new_locate, now_sort)
 
                         if node_id:
                             node_sink = '&{}'.format(node_id)
@@ -508,7 +508,7 @@ class DataflowGenerate:
                             node_source = node_typename
                             flow_type = node_typename
 
-                            node_id, new_node = self.deep_obj_address_generate(node_elseif.expr, new_locate, -1)
+                            node_id, new_node = self.deep_obj_address_generate(node_elseif.expr, new_locate, now_sort)
 
                             if node_id:
                                 node_sink = '&{}'.format(node_id)


### PR DESCRIPTION
### Motivation
- Conditional expressions (e.g. `if(a($d))`, `while(b($x))`) were expanded using an internal sort marker (`now_sort=-1`) which caused function-call nodes inside conditions to be recorded as internal/addressed nodes and therefore harder to query from the generated CodeDB, corresponding to issue #103. 
- The intent is to make condition-contained function calls appear in the normal, searchable ordering so they can be discovered and traced like other nodes.

### Description
- Changed `deep_obj_address_generate(..., -1)` calls to use the current statement sort (`now_sort`) for condition expressions in `base_dataflow_generate`. 
- Updated three call sites in `core/plugins/phpunserializechain/dataflowgenerate.py`: the `While`/`DoWhile` condition, the `If` condition, and `ElseIf` condition expansion. 
- This causes function-call nodes produced from condition expressions to be emitted with regular positive sort values instead of hidden internal addresses.

### Testing
- Compiled the modified module successfully with `python -m py_compile core/plugins/phpunserializechain/dataflowgenerate.py` (success). 
- Ran an AST-level reproduction script that parses snippets like `<?php if(a($d)){echo $d;} elseif(b($d)) {echo 1;}` and verified condition calls (`a`, `b`) are emitted as `FunctionCall` rows with positive `node_sort` values (observed expected output). 
- Performed a smoke run of the code generation path that produced `self.dataflows` entries showing the corrected ordering (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1ef9d7e8832da7cb7563d44bd9d3)