### PR TITLE
Trace other RHS variables for self-concatenation assignments (fix Issue #62)

### DIFF
--- a/core/core_engine/php/parser.py
+++ b/core/core_engine/php/parser.py
@@ -993,20 +993,43 @@ def parameters_back(param, nodes, function_params=None, lineno=0,
                 code = "{}={}".format(param_name, param_expr)
                 scan_chain.append(('ListAssignment', code, file_path, node.lineno))
 
-                # 如果目标参数就在列表中，就会有新的问题，这里选择，如果存在，则跳过
+                # 如果目标参数就在列表中，不能直接跳过，需要继续分析列表中的其他变量来源
                 if param_name in param_expr:
-                    logger.debug("[AST] param {} in list {}, continue...".format(param_name, param_expr))
+                    logger.debug("[AST] param {} in list {}, trace other params...".format(param_name, param_expr))
 
-                    # 如果列表中直接就有可控变量，先算作漏洞
+                    fallback_cp = None
                     for p in param_expr:
-                        is_co, cp = is_controllable(p)
+                        # 跳过被赋值变量自身，避免在自拼接场景下提前中断
+                        if p == param_name:
+                            continue
 
+                        is_co, cp = is_controllable(p)
                         if is_co == 1:
                             param = p
                             return is_co, cp, expr_lineno
 
-                    is_co = 3
-                    cp = param
+                        if is_co == -1:
+                            continue
+
+                        file_path = os.path.normpath(file_path)
+                        code = "find param {}".format(p)
+                        scan_chain.append(('NewFind', code, file_path, node.lineno))
+
+                        _is_co, _cp, expr_lineno = parameters_back(php.Variable(p), nodes[:-1], function_params, lineno,
+                                                                   function_flag=1, vul_function=vul_function,
+                                                                   file_path=file_path,
+                                                                   isback=isback)
+                        if _is_co == 1:
+                            is_co = _is_co
+                            cp = _cp
+                            break
+
+                        if _is_co in [-1, 3] and isinstance(p, str) and p.startswith('$'):
+                            fallback_cp = _cp if _is_co == 3 else build_ast_param(p)
+
+                    if is_co != 1:
+                        is_co = 3
+                        cp = fallback_cp if fallback_cp is not None else param
 
                 else:
                     fallback_cp = None
@@ -1467,12 +1490,44 @@ def parameters_back(param, nodes, function_params=None, lineno=0,
                     code = "{}.={}".format(param_name, param_expr)
                     scan_chain.append(('ListAssignmentOp', code, file_path, node.lineno))
 
-                    # 如果目标参数就在列表中，就会有新的问题，这里选择，如果存在，则跳过
+                    # 如果目标参数就在列表中，继续分析列表中的其他变量来源
                     if param_name in param_expr:
-                        logger.debug("[AST] param {} in list {}, continue...".format(param_name, param_expr))
+                        logger.debug("[AST] param {} in list {}, trace other params...".format(param_name, param_expr))
 
-                        is_co = 3
-                        cp = param
+                        fallback_cp = None
+                        for expr in param_expr:
+                            # 跳过被赋值变量自身，避免在自拼接场景下提前中断
+                            if expr == param_name:
+                                continue
+
+                            is_co, cp = is_controllable(expr)
+
+                            if is_co == 1:
+                                return is_co, cp, expr_lineno
+
+                            if is_co == -1:
+                                continue
+
+                            file_path = os.path.normpath(file_path)
+                            code = "find param {}".format(expr)
+                            scan_chain.append(('NewFind', code, file_path, node.lineno))
+
+                            _is_co, _cp, expr_lineno = parameters_back(php.Variable(expr), nodes[:-1], function_params, lineno,
+                                                                       function_flag=1, vul_function=vul_function,
+                                                                       file_path=file_path,
+                                                                       isback=isback)
+
+                            if _is_co == 1:
+                                is_co = _is_co
+                                cp = _cp
+                                break
+
+                            if _is_co in [-1, 3] and isinstance(expr, str) and expr.startswith('$'):
+                                fallback_cp = _cp if _is_co == 3 else build_ast_param(expr)
+
+                        if is_co != 1:
+                            is_co = 3
+                            cp = fallback_cp if fallback_cp is not None else param
 
                     else:
                         for expr in param_expr:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -463,3 +463,41 @@ if(isset($_GET['submit']) && $_GET['message'] != null){
             os.remove(temp_file)
         ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', files)
         ast_object.pre_ast_all(['php'])
+
+
+def test_anlysis_params_self_concat_assignment_tracks_other_rhs_vars():
+    """
+    回归测试：`$pid = $pid . $did` 这类右值包含自身变量的拼接赋值，
+    仍应继续追踪 `$did` 等其他变量来源（Issue #62）。
+    """
+    code = """<?php
+function add_func($did){
+    $did = $_GET['maple'];
+    $pid = "random";
+    $pid = $pid . $did;
+    $a = $pid ^ 'randow';
+    $b = $a . 'aaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    mysql_query($b);
+}
+"""
+    temp_file = PROJECT_DIRECTORY + '/tests/vulnerabilities/v_issue_62_runtime.php'
+    try:
+        with open(temp_file, 'w') as f:
+            f.write(code)
+
+        runtime_files = [('.php', {'list': ["v_issue_62_runtime.php"]})]
+        ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', runtime_files)
+        ast_object.pre_ast_all(['php'])
+
+        result = scan_parser(['mysql_query'], 8, temp_file)
+
+        assert isinstance(result, list)
+        assert result
+        assert result[0].get('code') == 1
+        assert result[0].get('source') is not None
+        assert result[0].get('source').name == '$_GET'
+    finally:
+        if os.path.exists(temp_file):
+            os.remove(temp_file)
+        ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', files)
+        ast_object.pre_ast_all(['php'])


### PR DESCRIPTION
### Motivation
- Fix cases where assignments like `$pid = $pid . $did` would short-circuit and stop tracking the real RHS sources, causing missed taint propagation (Issue #62).
- Improve taint tracing when a target variable appears in the RHS list so other elements in the list are analyzed instead of being skipped.

### Description
- Update `core/core_engine/php/parser.py` to continue tracing other variables when `param_name` is found inside `param_expr` for both `ListAssignment` and `ListAssignmentOp` cases, instead of immediately marking the target as fallback taint (`is_co = 3`).
- When iterating RHS entries, skip the target variable itself to avoid premature termination in self-concatenation scenarios, and invoke `parameters_back` recursively on other RHS variables to discover controllable sources. 
- Add fallback logic to prefer discovered taint sources (`fallback_cp`) when recursive tracing returns partial results and no direct controllable source is found.
- Add a unit test `test_anlysis_params_self_concat_assignment_tracks_other_rhs_vars` in `tests/test_parser.py` that reproduces the `$pid = $pid . $did` scenario and asserts the taint source `$_GET` is detected for the sink call `mysql_query`.

### Testing
- Ran the parser unit tests in `tests/test_parser.py`, including the new `test_anlysis_params_self_concat_assignment_tracks_other_rhs_vars` test.
- The new test verifies that a taint originating from `$_GET` is traced through a self-concatenation assignment to the sink and the assertions pass. 
- All executed parser tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2685227c832d974d8131369f5fea)