### PR TITLE
javascript: handle eval('name') pseudo-syntax in parameter backtracking (fix Issue #50)

### DIFF
--- a/core/core_engine/javascript/parser.py
+++ b/core/core_engine/javascript/parser.py
@@ -170,7 +170,7 @@ def get_param(param, is_eval=False, is_function_regex=False):
     elif type == "CallExpression":
         call_function = get_member_data(param.callee, isparam=True)
 
-        if is_function_regex:
+        if is_function_regex and call_function not in special_eval_function:
             params = [param.callee]
 
         else:
@@ -1149,6 +1149,14 @@ def parameters_back(param, nodes, function_params=None, lineno=0,
 
                     # 恶意函数调用
                     for param in callee_params:
+                        # issue #50:
+                        # eval('callback') 这类伪语法会让参数在调用处变成字符串字面量，
+                        # 但其语义上代表变量名，需要继续按变量回溯。
+                        if vul_function in special_eval_function \
+                                and hasattr(param, "type") and param.type == "Literal" \
+                                and isinstance(param.value, str):
+                            param = check_param(param.value, vul_lineno=param.loc.start.line)
+
                         is_co, cp, expr_lineno = parameters_back(param, nodes[:-1], function_params, lineno,
                                                                  function_flag=0, vul_function=vul_function,
                                                                  file_path=file_path,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -26,6 +26,7 @@ from core.core_engine.php.parser import anlysis_params
 from core.core_engine.php.parser import new_class_back
 from core.core_engine.php.parser import parameters_back
 from core.core_engine.php.parser import scan_parser
+from core.core_engine.javascript.parser import scan_parser as js_scan_parser
 from core.pretreatment import ast_object
 from core.pretreatment import Pretreatment
 from phply import phpast as php
@@ -259,6 +260,45 @@ echo $name;
 
         assert temp_file in ast_object.pre_result
         assert ast_object.pre_result[temp_file]['ast_nodes']
+    finally:
+        if os.path.exists(temp_file):
+            os.remove(temp_file)
+        ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', files)
+        ast_object.pre_ast_all(['php'])
+
+
+def test_javascript_eval_pseudo_syntax_issue_50():
+    """
+    回归测试（Issue #50）：
+    setTimeout(eval('callback'), ...) 不应把参数退化为 `eval`，
+    应继续提取并回溯到 `callback`。
+    """
+    code = """\
+function timedMsg(abc,callback){
+if(callback){
+var t=setTimeout(eval('callback'),3000);
+return 0;
+}
+}
+function fire(){
+var call = location.hash.split("#")[1];
+timedMsg(12,"call");
+}
+"""
+    temp_file = PROJECT_DIRECTORY + '/tests/vulnerabilities/v_issue50_runtime.js'
+    try:
+        with open(temp_file, 'w') as f:
+            f.write(code)
+
+        runtime_files = [('.js', {'list': ["v_issue50_runtime.js"]})]
+        ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', runtime_files)
+        ast_object.pre_ast_all(['javascript'])
+
+        results = js_scan_parser(['setTimeout'], 3, temp_file)
+
+        assert isinstance(results, list)
+        assert any(r.get('sink_param:') == 'callback' for r in results)
+        assert not any(r.get('sink_param:') == 'eval' for r in results)
     finally:
         if os.path.exists(temp_file):
             os.remove(temp_file)


### PR DESCRIPTION
### Motivation

- Fix incorrect parameter backtracking when JavaScript special-eval functions (like `eval`) are invoked with a string literal that names a callback, which previously caused the argument to be treated as a literal and halted taint/backtrace propagation.

### Description

- Update `core/core_engine/javascript/parser.py` so `get_param` does not treat calls to functions in `special_eval_function` as function-regex wrappers in the `is_function_regex` branch by adjusting the condition to exclude `special_eval_function` members. 
- Add handling in `parameters_back` to detect when a `special_eval_function` is called with a string `Literal` and convert that literal into a parameter node using `check_param(param.value, vul_lineno=...)` so backtracking continues (commented as `issue #50`).
- Add a unit test `test_javascript_eval_pseudo_syntax_issue_50` to `tests/test_parser.py` that exercises `setTimeout(eval('callback'), ...)` and asserts the sink parameter is resolved to `callback` and not `eval`, and import `scan_parser` from the JS parser as `js_scan_parser` for the test.

### Testing

- Ran the new unit test `pytest tests/test_parser.py::test_javascript_eval_pseudo_syntax_issue_50`, which passed. 
- Ran the parser tests in `tests/test_parser.py` after the change to ensure no regressions in the existing PHP/JS parser tests, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2de1c20c832db6eec310abbeaaeb)