### PR TITLE
Trace PHP `global` variables to outer scope and detect `ArrayOffset` controllability

### DIFF
--- a/core/core_engine/php/parser.py
+++ b/core/core_engine/php/parser.py
@@ -454,6 +454,15 @@ def is_controllable(expr, flag=None):  # 获取表达式中的变量，看是否
     # 传入合并
     controlled_params += is_controlled_params
 
+    if isinstance(expr, php.ArrayOffset):
+        array_name = get_node_name(expr.node)
+
+        if array_name in controlled_params:
+            logger.debug('[AST] is_controllable --> {expr}'.format(expr=array_name))
+            if flag:
+                return 1, array_name
+            return 1, php.Variable(array_name)
+
     if isinstance(expr, php.ObjectProperty):
         return 3, expr
 
@@ -598,9 +607,14 @@ def array_back(param, nodes, vul_function=None, file_path=None, isback=None):  #
     # print(param_name)
     # print(param_expr)
 
+    is_co, cp = is_controllable(param)
+    expr_lineno = param.lineno
+
+    if is_co == 1:
+        return is_co, cp, expr_lineno
+
     is_co = 3
     cp = param
-    expr_lineno = param.lineno
 
     for node in nodes[::-1]:
         if isinstance(node, php.Assignment):
@@ -1122,6 +1136,20 @@ def parameters_back(param, nodes, function_params=None, lineno=0,
                                                          isback=isback, parent_node=None)
                 function_flag = 0
 
+                if is_co == 5:
+                    logger.debug("[AST] param {} declared as global in function {}, trace from outer scope.".format(
+                        param_name, node.name))
+
+                    file_path = os.path.normpath(file_path)
+                    code = "param {} declared by global in function {}".format(param_name, node.name)
+                    scan_chain.append(('Global', code, file_path, node.lineno))
+
+                    is_co, cp, expr_lineno = parameters_back(param, nodes[:-1], function_params, lineno,
+                                                             function_flag=0, vul_function=vul_function,
+                                                             file_path=file_path,
+                                                             isback=isback, parent_node=0)
+                    return is_co, cp, expr_lineno
+
                 if is_co == 3:  # 出现新的敏感函数，重新生成新的漏洞结构，进入新的遍历结构
 
                     # 检查函数是不是魔术方法
@@ -1561,6 +1589,17 @@ def parameters_back(param, nodes, function_params=None, lineno=0,
 
                                 logger.debug("[AST] Uncontrollable  Param {}. continue ast.")
                                 continue
+
+        elif isinstance(node, php.Global):
+            global_params = []
+            for global_node in node.nodes:
+                global_name = get_node_name(global_node)
+                if global_name is not None:
+                    global_params.append(global_name)
+
+            if param_name in global_params:
+                logger.debug("[AST] Find global {} in line {}, trace in outer scope.".format(param_name, node.lineno))
+                return 5, param, node.lineno
 
         if is_co == 3 or int(lineno) == node.lineno:  # 当is_co为True时找到可控，停止递归
             is_co, cp, expr_lineno = parameters_back(param, nodes[:-1], function_params, lineno,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -267,6 +267,40 @@ echo $name;
         ast_object.pre_ast_all(['php'])
 
 
+def test_anlysis_params_php_global_variable_flow():
+    """
+    回归测试：函数内通过 global 引入的变量应回溯到外层作用域（Issue #38）。
+    """
+    code = """<?php
+$b = $_GET['cmd'];
+function a() {
+    global $b;
+    eval($b);
+}
+a();
+"""
+    temp_file = PROJECT_DIRECTORY + '/tests/vulnerabilities/v_global_runtime.php'
+    try:
+        with open(temp_file, 'w') as f:
+            f.write(code)
+
+        runtime_files = [('.php', {'list': ["v_global_runtime.php"]})]
+        ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', runtime_files)
+        ast_object.pre_ast_all(['php'])
+
+        is_co, cp, expr_lineno, chain = anlysis_params('$b', temp_file, 5)
+
+        assert is_co == 1
+        assert cp.name == '$_GET'
+        assert expr_lineno == 2
+        assert isinstance(chain, list)
+    finally:
+        if os.path.exists(temp_file):
+            os.remove(temp_file)
+        ast_object.init_pre(PROJECT_DIRECTORY + '/tests/vulnerabilities/', files)
+        ast_object.pre_ast_all(['php'])
+
+
 def test_javascript_eval_pseudo_syntax_issue_50():
     """
     回归测试（Issue #50）：


### PR DESCRIPTION
### Motivation

- Fix taint/backtrace handling for variables declared with `global` inside functions so they are traced to the outer scope instead of being missed. 
- Treat array offsets like `$_GET['key']` as controllable inputs so they are recognized by the sink-detection logic.

### Description

- Update `is_controllable` to recognize `php.ArrayOffset` nodes and return a controllable indicator and the corresponding variable when the base array is in the controlled list. 
- Short-circuit `array_back` by checking `is_controllable` early and returning when the array element is directly controllable. 
- Add handling in `parameters_back` to interpret a special return code (`5`) indicating a `global` declaration and re-trace the parameter in the outer scope while appending a `scan_chain` entry. 
- Add detection for `php.Global` nodes during backtracing to return the special code when a parameter is declared `global` in a function. 
- Add a unit test `test_anlysis_params_php_global_variable_flow` in `tests/test_parser.py` that verifies a variable brought into a function via `global` is traced back to `$_GET`.

### Testing

- Ran the new unit test `tests/test_parser.py::test_anlysis_params_php_global_variable_flow` which asserts the global-flow backtrace and it passed. 
- Ran the PHP parser test file `tests/test_parser.py` (including the existing regression tests) and the test suite completed successfully. 
- No automated tests failed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb32816204832d83a8ddb13e123457)