### PR TITLE
fix: 在 include 文件名解析中处理复杂的 define 值

### DIFF
--- a/core/core_engine/php/parser.py
+++ b/core/core_engine/php/parser.py
@@ -392,10 +392,26 @@ def get_filename(node, file_path):  # 获取filename
             constant_node_name = constant_node.name
 
             # 尝试做一些处理针对右值非常量的问题
+            define_value = ast_object.get_define(constant_node_name)
 
-            filenames[i] = ast_object.get_define(constant_node_name)
+            # define 右值可能不是纯字符串，例如 BinaryOp('.', $prefix, 'users')。
+            # 将其尽可能展开为字符串片段列表，避免后续 join 时出现类型错误。
+            if isinstance(define_value, php.BinaryOp):
+                filenames[i] = get_binaryop_params(define_value)
+            elif isinstance(define_value, php.Variable):
+                filenames[i] = define_value.name
+            elif isinstance(define_value, php.Constant):
+                nested_define = ast_object.get_define(define_value.name)
+                if isinstance(nested_define, php.BinaryOp):
+                    filenames[i] = get_binaryop_params(nested_define)
+                elif isinstance(nested_define, php.Variable):
+                    filenames[i] = nested_define.name
+                else:
+                    filenames[i] = nested_define
+            else:
+                filenames[i] = define_value
 
-    return filenames
+    return export_list(filenames, [])
 
 
 def is_repair(expr):


### PR DESCRIPTION
### Motivation
- 修复在通过 `define()` 常量构造 include/require 路径时遇到非常量右值（例如 `BinaryOp('.', $prefix, 'table')`）导致类型错误或路径拼接异常的问题。

### Description
- 在 `get_filename` 中改为先通过 `ast_object.get_define(...)` 获取常量右值并保存在 `define_value` 中以便进一步处理。 
- 支持当 `define` 的右值为 `php.BinaryOp`、`php.Variable` 或嵌套的 `php.Constant` 时展开为可拼接的字符串片段或变量名。 
- 在返回前通过 `export_list(...)` 将 `filenames` 扁平化，避免后续对 `"".join(filename)` 时因嵌套列表而抛出 `TypeError`。
- 修改影响文件：`core/core_engine/php/parser.py`（`get_filename` 函数）。

### Testing
- 运行了语法检查 `python -m py_compile core/core_engine/php/parser.py`，执行成功且无语法错误。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb42a00f78832d91c713688c8d9030)