### PR TITLE
fix(js): 处理所有 JS `function-regex` 命中结果 (fix #35)

### DIFF
--- a/core/engine.py
+++ b/core/engine.py
@@ -1013,25 +1013,32 @@ class Core(object):
                                                 controlled_params=self.controlled_list)
                         logger.debug('[AST] [RET] {c}'.format(c=result))
                         if len(result) > 0:
-                            if result[0]['code'] == 1:  # 函数参数可控
-                                return True, 'Function-param-controllable', result[0]['chain']
+                            result_code_list = []
 
-                            elif result[0]['code'] == 2:  # 漏洞修复
-                                return False, 'Function-param-controllable but fixed', result[0]['chain']
+                            for r in result:
+                                result_code_list.append(r['code'])
 
-                            elif result[0]['code'] == 3:  # 疑似漏洞
-                                if self.is_unconfirm:
-                                    return True, 'Unconfirmed Function-param-controllable', result[0]['chain']
-                                else:
-                                    return False, 'Unconfirmed Function-param-controllable', result[0]['chain']
+                                if r['code'] == 1:  # 函数参数可控
+                                    return True, 'Function-param-controllable', r['chain']
 
-                            elif result[0]['code'] == -1:  # 函数参数不可控
-                                return False, 'Function-param-uncon', result[0]['chain']
+                            for r in result:
+                                if r['code'] == 4:  # 新规则生成
+                                    return False, 'New Core', r['source']
 
-                            elif result[0]['code'] == 4:  # 新规则生成
-                                return False, 'New Core', result[0]['source']
+                            for r in result:
+                                if r['code'] == 3:  # 疑似漏洞
+                                    if self.is_unconfirm:
+                                        return True, 'Unconfirmed Function-param-controllable', r['chain']
+                                    else:
+                                        return False, 'Unconfirmed Function-param-controllable', r['chain']
 
-                            logger.debug('[AST] [CODE] {code}'.format(code=result[0]['code']))
+                                elif r['code'] == 2:  # 漏洞修复
+                                    return False, 'Function-param-controllable but fixed', r['chain']
+
+                                else:  # 函数参数不可控
+                                    return False, 'Function-param-uncon', r['chain']
+
+                            logger.debug('[AST] [CODE] {code}'.format(code=result_code_list))
                         else:
                             logger.debug(
                                 '[AST] Parser failed / vulnerability parameter is not controllable {r}'.format(


### PR DESCRIPTION
### Motivation
- 修复在 JavaScript `function-regex` 模式下只检查 `result[0]` 导致后续命中被忽略的问题，从而造成漏报或误判（对应 issue #35）。
- 使 JS 分支的决策优先级与 PHP 分支一致，以确保在同一行存在多个敏感函数调用时得到正确结果。

### Description
- 在 `core/engine.py` 的 JS 分支（`mm_function_param_controllable`）改为遍历 `js_scan_parser` 返回的全部 `result` 并收集 `result_code_list`。
- 优先立即返回 `code == 1`（函数参数可控），其次处理 `code == 4`（新规则生成），最后处理 `code == 3/2/-1`（疑似/已修复/不可控），并记录完整的 `result_code_list` 用于诊断。  
- 未修改其它匹配模式或异常处理逻辑，保持与现有流程兼容。

### Testing
- 运行 `python -m py_compile core/engine.py`，结果成功（无语法错误）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb43a4337c832dafba63708af31eb2)