### PR TITLE
Reorganize and update runtime dependencies in requirements.txt for Python 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,23 @@
-pyjsparser
-colorlog>=6.8.2
-phply==1.0.0
-portalocker>=2.8.2
-prettytable>=3.10.0
-rarfile>=4.2
-requests>=2.32.3
+# Kunlun-M runtime dependencies (Python 3.13)
+# Install: python3.13 -m pip install -r requirements.txt
+
+# Web framework
+django>=4.2,<6
 Werkzeug>=3.0.6
+
+# Parser / analysis stack
+phply==1.0.0
 esprima==4.0.1
+pyjsparser>=2.7.1
 jsbeautifier>=1.15.1
 beautifulsoup4>=4.12.3
-django>=4.2,<6
+
+# Output & utilities
+colorlog>=6.8.2
+prettytable>=3.10.0
+portalocker>=2.8.2
+requests>=2.32.3
+rarfile>=4.2
+
+# Database drivers
 mysqlclient>=2.2.4


### PR DESCRIPTION
### Motivation
- Align the project's runtime dependencies with a target of Python 3.13 and make the dependency list clearer for maintainers. 
- Ensure required web, parsing, and DB driver packages are explicitly listed and versioned for reproducible installs. 

### Description
- Rewrote `requirements.txt` with a header comment and an install hint pointing to `python3.13 -m pip install -r requirements.txt`. 
- Added and grouped sections for the web framework (`django>=4.2,<6` and `Werkzeug>=3.0.6`), parser/analysis tools (`esprima==4.0.1`, `pyjsparser>=2.7.1`, `jsbeautifier>=1.15.1`, `beautifulsoup4>=4.12.3`, `phply==1.0.0`), output/utilities (`colorlog`, `prettytable`, `portalocker`, `requests`, `rarfile`), and database drivers (`mysqlclient>=2.2.4`). 
- Reordered and standardized version pins for clarity and maintainability. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eec85fb678832db8adf848fa84d293)