### PR TITLE
Use set_defaults for console subparser and add CLI compatibility tests

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -123,8 +123,7 @@ def main():
                                                      description=__introduction__.format(detail='enter console mode'),
                                                      formatter_class=argparse.RawDescriptionHelpFormatter,
                                                      usage=argparse.SUPPRESS, add_help=True)
-        parser_group_console.add_argument('console', action='store_true', default=True,
-                                          help='enter console mode')
+        parser_group_console.set_defaults(console=True)
 
         # 加载插件参数列表以及帮助
 

--- a/tests/test_cli_py314_compat.py
+++ b/tests/test_cli_py314_compat.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+import os
+import subprocess
+import sys
+
+
+def _run_kunlun_command(*args):
+    project_root = os.path.dirname(os.path.dirname(__file__))
+    script = os.path.join(project_root, "kunlun.py")
+
+    return subprocess.run(
+        [sys.executable, script, *args],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_cli_help_works():
+    result = _run_kunlun_command("-h")
+    assert result.returncode == 0
+    assert "Main Program" in result.stdout
+
+
+def test_console_subcommand_help_works():
+    result = _run_kunlun_command("console", "-h")
+    assert result.returncode == 0
+    assert "enter console mode" in result.stdout


### PR DESCRIPTION
### Motivation

- Fix argparse compatibility for the `console` subcommand (avoids creating a positional argument that can conflict with subparser handling in newer Python versions). 

### Description

- Replace `parser_group_console.add_argument('console', ...)` with `parser_group_console.set_defaults(console=True)` to set the console flag without registering a positional argument.
- Add `tests/test_cli_py314_compat.py` which calls the `kunlun.py` script with `-h` and `console -h` to validate CLI help output.
- Add a trailing newline at the end of `core/__init__.py` (formatting fix).

### Testing

- Ran `pytest tests/test_cli_py314_compat.py` and both tests (`test_cli_help_works` and `test_console_subcommand_help_works`) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eecd6872a0832d9395057ab3116992)