### PR TITLE
Fix SQLite migration failure for func_hash/vul_hash defaults

### DIFF
--- a/web/index/migrations/0004_auto_20210720_1649.py
+++ b/web/index/migrations/0004_auto_20210720_1649.py
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='newevilfunc',
             name='func_hash',
-            field=models.CharField(default=None, max_length=32),
+            field=models.CharField(default='', max_length=32),
         ),
         migrations.AddField(
             model_name='newevilfunc',
@@ -42,7 +42,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='scanresulttask',
             name='vul_hash',
-            field=models.CharField(default=None, max_length=32),
+            field=models.CharField(default='', max_length=32),
         ),
         migrations.AddField(
             model_name='scantask',

--- a/web/index/models.py
+++ b/web/index/models.py
@@ -254,7 +254,7 @@ class ScanResultTask(models.Model):
     vulfile_path = models.CharField(max_length=200)
     source_code = models.CharField(max_length=200)
     result_type = models.CharField(max_length=100)
-    vul_hash = models.CharField(max_length=32, default=None)
+    vul_hash = models.CharField(max_length=32, default='')
     is_unconfirm = models.BooleanField(default=False)
     is_active = models.BooleanField(default=True)
 
@@ -372,7 +372,7 @@ class NewEvilFunc(models.Model):
     project_id = models.IntegerField(default=0)
     func_name = models.CharField(max_length=200)
     origin_func_name = models.CharField(max_length=200, null=True)
-    func_hash = models.CharField(max_length=32, default=None)
+    func_hash = models.CharField(max_length=32, default='')
     is_active = models.BooleanField(default=True)
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
### Motivation
- Adding non-null `CharField` columns with `default=None` caused Django to remake SQLite tables and insert `NULL`, triggering `IntegrityError: NOT NULL constraint failed` during `kunlun.py init initialize`.
- Ensure model defaults and migration defaults are consistent so initialization does not produce a follow-up migration or fail on existing databases.

### Description
- Updated migration `web/index/migrations/0004_auto_20210720_1649.py` to use empty-string defaults for the added fields `func_hash` and `vul_hash` instead of `None`.
- Aligned model definitions in `web/index/models.py` by changing `NewEvilFunc.func_hash` and `ScanResultTask.vul_hash` to use `default=''` instead of `default=None` to match migration semantics.
- These changes prevent Django/SQLite from trying to insert `NULL` into newly-added non-null `CharField` columns.

### Testing
- Ran `python ./kunlun.py init initialize` on a fresh database and verified migrations applied successfully and output shows `No changes detected` and migration steps completed through `index.0009_projectvendors_source`.
- Re-ran initialization after removing the local DB file and confirmed the init sequence finishes without `IntegrityError` and reports `Init Database Finished.`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eed4de5778832daa6f89ce05b201e7)