### PR TITLE
Use raw string literals for regex patterns to fix invalid escape sequence warnings

### DIFF
--- a/rules/javascript/CVI_3005.py
+++ b/rules/javascript/CVI_3005.py
@@ -63,7 +63,7 @@ class CVI_3005():
             return result
         sql_sen = regex_string[0][0]
         # reg = "[\w_.]+"
-        reg = "((?<=\(|,|=|\+)\s*((\"[^\"]+?\")|('[^']+')|[\w_\.]+))"
+        reg = r"((?<=\(|,|=|\+)\s*((\"[^\"]+?\")|('[^']+')|[\w_\.]+))"
 
         if re.search(reg, sql_sen, re.I):
 

--- a/rules/javascript/CVI_30051.py
+++ b/rules/javascript/CVI_30051.py
@@ -63,7 +63,7 @@ class CVI_30051():
             return result
         sql_sen = regex_string[0][0]
         # reg = "[\w_.]+"
-        reg = "((?<=\(|,|=|\+)\s*((\"[^\"]+?\")|('[^']+')|[\w_\.]+))"
+        reg = r"((?<=\(|,|=|\+)\s*((\"[^\"]+?\")|('[^']+')|[\w_\.]+))"
 
         if re.search(reg, sql_sen, re.I):
 

--- a/rules/javascript/CVI_3006.py
+++ b/rules/javascript/CVI_3006.py
@@ -52,7 +52,7 @@ class CVI_3006():
         :return: 
         """
         sql_sen = regex_string[0][1]
-        reg = "[\w_.]+"
+        reg = r"[\w_.]+"
         if re.search(reg, sql_sen, re.I):
 
             p = re.compile(reg)

--- a/rules/javascript/CVI_30061.py
+++ b/rules/javascript/CVI_30061.py
@@ -52,7 +52,7 @@ class CVI_30061():
         :return:
         """
         sql_sen = regex_string[0][1]
-        reg = "[\w_.]+"
+        reg = r"[\w_.]+"
         if re.search(reg, sql_sen, re.I):
 
             p = re.compile(reg)

--- a/rules/javascript/CVI_3011.py
+++ b/rules/javascript/CVI_3011.py
@@ -68,7 +68,7 @@ class CVI_3011():
             return result
 
         sql_sen = regex_string[0][4]
-        reg = "((?<=:)\s*([\w_\.]+))"
+        reg = r"((?<=:)\s*([\w_\.]+))"
         if re.search(reg, sql_sen, re.I):
             p = re.compile(reg)
             match = p.findall(sql_sen)

--- a/rules/javascript/CVI_30111.py
+++ b/rules/javascript/CVI_30111.py
@@ -52,7 +52,7 @@ class CVI_30111():
         :return:
         """
         sql_sen = regex_string[0][1]
-        reg = "((?<=\()\s*([\w_\.]+))"
+        reg = r"((?<=\()\s*([\w_\.]+))"
         if re.search(reg, sql_sen, re.I):
             p = re.compile(reg)
             match = p.findall(sql_sen)

--- a/rules/php/CVI_10001.py
+++ b/rules/php/CVI_10001.py
@@ -52,7 +52,7 @@ class CVI_10001():
         :return:
         """
         sql_sen = regex_string[0][0]
-        reg = "\$\w+"
+        reg = r"\$\w+"
         if re.search(reg, sql_sen, re.I):
             p = re.compile(reg)
             match = p.findall(sql_sen)

--- a/rules/php/CVI_1001.py
+++ b/rules/php/CVI_1001.py
@@ -52,7 +52,7 @@ class CVI_1001():
         :return: 
         """
         sql_sen = regex_string[0]
-        reg = "\$[\w+\->]*"
+        reg = r"\$[\w+\->]*"
         if re.search(reg, sql_sen, re.I):
 
             p = re.compile(reg)

--- a/rules/php/CVI_1004.py
+++ b/rules/php/CVI_1004.py
@@ -52,7 +52,7 @@ class CVI_1004():
         :return: 
         """
         sql_sen = regex_string[0][0]
-        reg = "\$\w+"
+        reg = r"\$\w+"
         if re.search(reg, sql_sen, re.I):
 
             p = re.compile(reg)


### PR DESCRIPTION
### Motivation
- Replace regex literals that raised Python `SyntaxWarning: invalid escape sequence` to remove warnings and prevent future string-escape issues while preserving intended regex behavior.

### Description
- Converted multiple regex assignments from normal string literals to raw string literals (`r"..."`) in JavaScript and PHP rule modules so backslashes are preserved for the regex engine rather than being interpreted as Python escape sequences.
- Updated files: `rules/javascript/CVI_3005.py`, `rules/javascript/CVI_30051.py`, `rules/javascript/CVI_3006.py`, `rules/javascript/CVI_30061.py`, `rules/javascript/CVI_3011.py`, `rules/javascript/CVI_30111.py`, `rules/php/CVI_10001.py`, `rules/php/CVI_1001.py`, and `rules/php/CVI_1004.py`.
- No functional changes to the regex patterns or rule logic were made; only the string literal representation was changed.

### Testing
- Ran `python -Wall -m py_compile` against the modified files and compilation completed with no warnings.
- All updated modules compiled successfully with the updated raw-string regex literals.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef023eb2b8832daf9f556393bbac91)