### PR TITLE
fix(console): avoid traceback after unknown console command

### DIFF
--- a/core/console.py
+++ b/core/console.py
@@ -175,7 +175,7 @@ class BaseInterpreter(object):
             command_handler = getattr(self, "command_{}".format(command))
         except AttributeError:
             logger.error("Unknown command: '{}'".format(command))
-            return False
+            return None
 
         return command_handler
 
@@ -190,6 +190,8 @@ class BaseInterpreter(object):
                 if not command:
                     continue
                 command_handler = self.get_command_handler(command)
+                if command_handler is None:
+                    continue
                 command_handler(args)
             except EOFError:
                 logger.info("KunLun-M Console mode stopped")


### PR DESCRIPTION
### Motivation
- Prevent a `TypeError` when an unknown console command is entered because the returned handler value was being invoked as a callable.

### Description
- Change `get_command_handler` to return `None` instead of `False` when a command handler is not found and keep the existing `Unknown command` log.
- Add a guard in the `start()` loop to skip execution when `get_command_handler` returns `None` so unknown commands are logged and not invoked.

### Testing
- Ran `python -m py_compile core/console.py` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef0443379c832da5d3a327f0a4b1cd)