### PR TITLE
Fix argument validation in console search/config commands

### DIFF
--- a/core/console.py
+++ b/core/console.py
@@ -1324,6 +1324,7 @@ Input Control:
 
         if len(param) < 3:
             logger.error("[Console] Command Search need to set 'mod' 'keyword' 'keyvalue'.e.g.: search vendor flask 0.10.1")
+            return
 
         mod = param[0]
         keyword = param[1]
@@ -1342,6 +1343,7 @@ Input Control:
 
         if len(param) < 2:
             logger.error("[Console] Command Config need to set 'mod' and 'keyword'.e.g.: config rule 1001")
+            return
 
         mod = param[0]
         keyword = param[1]


### PR DESCRIPTION
### Motivation
- Prevent crashes when console commands `search` or `config` are invoked with too few arguments by ensuring the methods don't proceed after logging an error.

### Description
- Added early `return` statements in `command_search` and `command_config` in `core/console.py` so the code does not index into `param` when its length is insufficient.

### Testing
- Compiled `core/console.py` with `python -m py_compile core/console.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef05eb72c8832d9ff813f7fc03c96b)