### PR TITLE
fix: restore console tab completion by hardening readline backend loading

### DIFF
--- a/tests/test_readlineng.py
+++ b/tests/test_readlineng.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+import importlib
+import types
+
+import Kunlun_M.settings as settings
+
+
+def _build_fake_readline_module(with_get_output_file=True):
+    module = types.ModuleType("fake_readline")
+    module.parse_and_bind = lambda *args, **kwargs: None
+    module.set_completer = lambda *args, **kwargs: None
+    module.set_completer_delims = lambda *args, **kwargs: None
+    module.read_history_file = lambda *args, **kwargs: None
+    module.write_history_file = lambda *args, **kwargs: None
+    module.set_history_length = lambda *args, **kwargs: None
+    module.clear_history = lambda *args, **kwargs: None
+    module.get_line_buffer = lambda: ""
+    module.get_begidx = lambda: 0
+    module.get_endidx = lambda: 0
+
+    if with_get_output_file:
+        module.GetOutputFile = lambda: None
+
+    return module
+
+
+def test_windows_backend_without_getoutputfile_still_available(monkeypatch):
+    fake_backend = _build_fake_readline_module(with_get_output_file=False)
+    monkeypatch.setitem(importlib.sys.modules, "readline", fake_backend)
+    monkeypatch.setattr(settings, "PLATFORM", "windows")
+
+    import utils.readlineng as readlineng
+
+    importlib.reload(readlineng)
+
+    assert readlineng._readline is fake_backend
+
+
+def test_fallback_to_pyreadline3_when_others_unavailable(monkeypatch):
+    fake_backend = _build_fake_readline_module()
+    original_import_module = importlib.import_module
+
+    def _fake_import_module(name, package=None):
+        if name in ("readline", "pyreadline"):
+            raise ImportError
+        if name == "pyreadline3":
+            return fake_backend
+        return original_import_module(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", _fake_import_module)
+    monkeypatch.setattr(settings, "PLATFORM", "windows")
+
+    import utils.readlineng as readlineng
+
+    importlib.reload(readlineng)
+
+    assert readlineng._readline is fake_backend

--- a/utils/readlineng.py
+++ b/utils/readlineng.py
@@ -9,32 +9,41 @@
 
 '''
 
+import importlib
+
 from .utils import logger
 
 from Kunlun_M.settings import PLATFORM
 
 _readline = None
 
-try:
-    from readline import *
-    import readline as _readline
-except ImportError:
-    try:
-        from pyreadline import *
-        import pyreadline as _readline
-    except ImportError:
-        # raise PocsuiteSystemException("Import pyreadline faild,try pip3 install pyreadline")
-        pass
+
+def _load_readline():
+    for module_name in ("readline", "pyreadline", "pyreadline3"):
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError:
+            continue
+
+        for attr in dir(module):
+            if not attr.startswith("_"):
+                globals()[attr] = getattr(module, attr)
+
+        return module
+
+    return None
+
+
+_readline = _load_readline()
 
 if PLATFORM == 'windows' and _readline:
     try:
-        _outputfile = _readline.GetOutputFile()
+        if hasattr(_readline, "GetOutputFile"):
+            _outputfile = _readline.GetOutputFile()
     except AttributeError:
         debugMsg = "Failed GetOutputFile when using platform's "
         debugMsg += "readline library"
         logger.debug(debugMsg)
-
-        _readline = None
 
 # Test to see if libedit is being used instead of GNU readline.
 # Thanks to Boyd Waters for this patch.


### PR DESCRIPTION
### Motivation
- Console tab-completion was silently disabled on some platforms because `utils/readlineng.py` cleared the `_readline` backend when a Windows-specific attribute (`GetOutputFile`) was missing.  
- The original import logic also did not handle newer Windows-compatible backends like `pyreadline3`, reducing compatibility across Python versions and platforms.  

### Description
- Rewrote backend initialization in `utils/readlineng.py` to use `importlib.import_module` and attempt `readline`, `pyreadline`, then `pyreadline3`, returning the first available provider.  
- Dynamically export the provider's public API into the module `globals()` so existing code can call functions like `parse_and_bind` and `set_completer`.  
- Fixed Windows logic so the absence of a `GetOutputFile` method no longer disables the `_readline` backend (only attempt the call when present).  
- Added regression tests in `tests/test_readlineng.py` that assert Windows behavior when `GetOutputFile` is missing and fallback to `pyreadline3` when other imports fail.  

### Testing
- Ran `pytest -q tests/test_readlineng.py tests/test_cli_py314_compat.py` and both tests completed successfully with `4 passed` (warnings only).  
- The new tests validate that `_readline` is set to the provider module in both the `GetOutputFile`-missing and fallback scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef0807a940832daed961aa14edd9e0)