### PR TITLE
Improve empty-result feedback for console search

### DIFF
--- a/core/cli.py
+++ b/core/cli.py
@@ -442,6 +442,7 @@ def search_project(search_type, keyword, keyword_value, with_vuls=False):
         j = 0
 
         if not ps:
+            logger.info("Search result is empty.")
             return False
 
         for p in ps:
@@ -466,8 +467,12 @@ def search_project(search_type, keyword, keyword_value, with_vuls=False):
                         table2.add_row([i, vv.vuln_id, vv.title, VENDOR_VUL_LEVEL[vv.severity], vv.cves, vv.reference, vv.vendor_name, vv.affected_versions])
 
         logger.info("Project List (Small than {} {}):\n{}".format(keyword, keyword_value, table))
-        logger.info("Vendor {}:{} Vul List:\n{}".format(keyword, keyword_value, table2))
+
+        if with_vuls:
+            if j == 0:
+                logger.info("Vendor {}:{} Vul List is empty.".format(keyword, keyword_value))
+            else:
+                logger.info("Vendor {}:{} Vul List:\n{}".format(keyword, keyword_value, table2))
 
     return True
-
 

--- a/core/console.py
+++ b/core/console.py
@@ -1334,7 +1334,9 @@ Input Control:
             return
 
         if mod == 'vendor':
-            cli.search_project(mod, keyword, keyvalue, with_vuls=True)
+            status = cli.search_project(mod, keyword, keyvalue, with_vuls=True)
+            if not status:
+                logger.info("[Console] Search result is empty.")
 
     def command_config(self, *args, **kwargs):
 


### PR DESCRIPTION
### Motivation
- Provide explicit feedback when a vendor search yields no projects or no vulnerability results so console users don't see no output and think the CLI hung.

### Description
- In `core/cli.py`'s `search_project`, log `"Search result is empty."` and return `False` when no projects are found.
- When `with_vuls` is enabled, avoid printing an empty vulnerability table and log `"Vendor <keyword>:<value> Vul List is empty."` if no vulnerabilities were collected.
- In `core/console.py`'s `command_search`, capture the return value of `cli.search_project` and log `"[Console] Search result is empty."` when the search returns `False`.

### Testing
- Ran `python -m py_compile core/cli.py core/console.py` and compilation completed successfully.
- No other automated tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef09cf5284832da875d382a524a86a)