### PR TITLE
feat(web): 深度美化首页并优化登录/注册弹窗流程

### DIFF
--- a/static/css/default.css
+++ b/static/css/default.css
@@ -1,6 +1,126 @@
 html{
 	height: 100%;
 }
+body.landing-body {
+    min-height: 100%;
+    background: #091224;
+}
+
+body.modal-open {
+    overflow: hidden;
+}
+
+.landing-hero {
+    background: radial-gradient(circle at top right, #4a6bff, #20163c 60%, #0b1221);
+}
+
+.landing-title {
+    font-size: 3rem;
+    letter-spacing: .5px;
+}
+
+.landing-subtitle {
+    color: rgba(255, 255, 255, 0.9) !important;
+    margin-bottom: 12px !important;
+}
+
+.landing-content {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 14px;
+    padding: 16px 18px;
+    color: #eff2ff;
+    max-width: 680px;
+}
+
+.landing-badge {
+    display: inline-block;
+    font-size: 12px;
+    letter-spacing: 1.2px;
+    font-weight: 700;
+    color: #81e6ff;
+    margin-bottom: 10px;
+}
+
+.landing-actions {
+    margin-top: 22px;
+    display: flex;
+    gap: 14px;
+    flex-wrap: wrap;
+}
+
+.landing-panel {
+    background: rgba(7, 11, 22, 0.55);
+    border: 1px solid rgba(129, 190, 255, 0.35);
+    border-radius: 16px;
+    padding: 22px;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, .28);
+}
+
+.landing-panel h4 {
+    margin-top: 0;
+    font-size: 20px;
+    color: #fff;
+    margin-bottom: 12px;
+}
+
+.landing-panel ul {
+    margin: 0;
+    padding: 0;
+}
+
+.landing-panel li {
+    list-style: none;
+    color: #e9f5ff;
+    margin-bottom: 10px;
+}
+
+.landing-panel li i {
+    color: #6ef0b2;
+    margin-right: 8px;
+}
+
+.landing-auth-modal .modal-card {
+    width: 92%;
+    max-width: 480px;
+    border-radius: 14px;
+    overflow: hidden;
+}
+
+.landing-auth-modal .modal-card-head {
+    background: linear-gradient(110deg, #1f5fff, #7338ff);
+}
+
+.landing-auth-modal .modal-card-title {
+    color: #fff;
+    font-weight: 600;
+}
+
+.landing-auth-modal .modal-card-body {
+    background: #f7f8ff;
+    padding: 24px;
+}
+
+.landing-auth-modal .tabs {
+    margin-bottom: 18px;
+}
+
+.landing-auth-modal .tabs li.is-active a {
+    background: #1f5fff;
+    border-color: #1f5fff;
+    color: #fff;
+}
+
+.auth-messages .notification {
+    margin-bottom: 14px !important;
+}
+
+@media (max-width: 768px) {
+    .landing-title {
+        font-size: 2.2rem;
+    }
+}
+
 ul.messages{
     padding-left: 0px !important;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,8 +11,8 @@
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 </head>
 
-<body>
-<section class="hero is-info is-large">
+<body class="landing-body">
+<section class="hero is-large landing-hero">
   <div class="hero-head">
     <nav class="navbar">
       <div class="container">
@@ -45,7 +45,7 @@
     </span>
 {% else %}
             <span class="navbar-item">
-              <a class="button is-info is-inverted" href="{% url 'index:register' %}">
+              <a class="button is-info is-inverted js-open-auth" data-auth-target="register" href="{% url 'index:register' %}">
                 <span class="icon">
                   <i class="fa fa-sign-in"></i>
                 </span>
@@ -53,7 +53,7 @@
               </a>
             </span>
             <span class="navbar-item">
-              <a class="button is-info is-inverted" href="{% url 'index:login' %}">
+              <a class="button is-info is-inverted js-open-auth" data-auth-target="login" href="{% url 'index:login' %}">
                 <span class="icon">
                   <i class="fa fa-sign-in"></i>
                 </span>
@@ -69,21 +69,192 @@
   </div>
 
   <div class="hero-body">
-    <div class="container has-text-centered">
-      <p class="title">
-        {{ title }}
-      </p>
-      <p class="subtitle">
-        Power by LoRexxar
-      </p>
-      <div class="content">
-        {{ description }}
+    <div class="container">
+      <div class="columns is-vcentered">
+        <div class="column is-7 has-text-left">
+          <p class="landing-badge">KUNLUN-M WEB MODE</p>
+          <p class="title landing-title">
+            {{ title }}
+          </p>
+          <p class="subtitle landing-subtitle">
+            面向代码安全审计的现代化扫描平台
+          </p>
+          <div class="content landing-content">
+            {{ description }}
+          </div>
+          <div class="landing-actions">
+            {% if user.is_authenticated %}
+              <a class="button is-primary is-medium is-rounded" href="{% url 'dashboard:index' %}">
+                进入控制台
+              </a>
+            {% else %}
+              <a class="button is-primary is-medium is-rounded js-open-auth" data-auth-target="login" href="{% url 'index:login' %}">
+                立即登录
+              </a>
+              {% if is_open_register %}
+              <a class="button is-light is-medium is-rounded js-open-auth" data-auth-target="register" href="{% url 'index:register' %}">
+                免费注册
+              </a>
+              {% endif %}
+            {% endif %}
+          </div>
+        </div>
+        <div class="column is-5">
+          <div class="landing-panel">
+            <h4>为什么选择 {{ title }}</h4>
+            <ul>
+              <li><i class="fa fa-check-circle"></i> 多语言规则引擎，快速发现高危漏洞</li>
+              <li><i class="fa fa-check-circle"></i> Web 页面与任务流深度整合，低学习成本</li>
+              <li><i class="fa fa-check-circle"></i> 支持项目、依赖、供应链多维安全视图</li>
+            </ul>
+          </div>
+        </div>
       </div>
     </div>
   </div>
 </section>
 
+{% if not user.is_authenticated %}
+<div class="modal landing-auth-modal" id="auth-modal">
+  <div class="modal-background"></div>
+  <div class="modal-card">
+    <header class="modal-card-head">
+      <p class="modal-card-title">账户中心</p>
+      <button class="delete js-close-auth" aria-label="close"></button>
+    </header>
+    <section class="modal-card-body">
+      <div class="tabs is-toggle is-fullwidth">
+        <ul>
+          <li class="auth-tab is-active" data-auth-target="login"><a>登录</a></li>
+          {% if is_open_register %}
+          <li class="auth-tab" data-auth-target="register"><a>注册</a></li>
+          {% endif %}
+        </ul>
+      </div>
+
+      {% if messages %}
+      <div class="auth-messages">
+        <ul class="messages">
+          {% for message in messages %}
+          <li{% if message.tags %} class="notification is-danger is-{{ message.tags }}"{% endif %}>{{ message }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+      {% endif %}
+
+      <div class="auth-panel" data-auth-panel="login">
+        <form id="login-form" method="post" action="{% url 'index:login' %}">
+          {% csrf_token %}
+          <div class="field">
+            <div class="control has-icons-left">
+              <input class="input" type="text" placeholder="用户名" name="username" required>
+              <span class="icon is-small is-left"><i class="fa fa-user"></i></span>
+            </div>
+          </div>
+          <div class="field">
+            <div class="control has-icons-left">
+              <input class="input" type="password" placeholder="密码" name="password" required>
+              <span class="icon is-small is-left"><i class="fa fa-lock"></i></span>
+            </div>
+          </div>
+          <button class="button is-info is-fullwidth">登录并继续</button>
+        </form>
+      </div>
+
+      {% if is_open_register %}
+      <div class="auth-panel is-hidden" data-auth-panel="register">
+        <form id="register-form" method="post" action="{% url 'index:register' %}">
+          {% csrf_token %}
+          <div class="field">
+            <div class="control has-icons-left">
+              <input class="input" type="text" placeholder="用户名" name="username" required minlength="3">
+              <span class="icon is-small is-left"><i class="fa fa-user"></i></span>
+            </div>
+          </div>
+          <div class="field">
+            <div class="control has-icons-left">
+              <input class="input" type="password" placeholder="密码" name="password1" required minlength="8">
+              <span class="icon is-small is-left"><i class="fa fa-lock"></i></span>
+            </div>
+          </div>
+          <div class="field">
+            <div class="control has-icons-left">
+              <input class="input" type="password" placeholder="确认密码" name="password2" required minlength="8">
+              <span class="icon is-small is-left"><i class="fa fa-shield"></i></span>
+            </div>
+          </div>
+          <button class="button is-primary is-fullwidth">创建账号</button>
+        </form>
+      </div>
+      {% endif %}
+    </section>
+  </div>
+</div>
+{% endif %}
+
 <script src="{% static 'js/jquery.min.js' %}"></script>
 <script src="{% static 'js/bootstrap.min.js' %}"></script>
+<script>
+(function () {
+  var authModal = document.getElementById('auth-modal');
+  if (!authModal) {
+    return;
+  }
+
+  function switchAuthPanel(target) {
+    var tabs = authModal.querySelectorAll('.auth-tab');
+    var panels = authModal.querySelectorAll('.auth-panel');
+    for (var i = 0; i < tabs.length; i++) {
+      tabs[i].classList.toggle('is-active', tabs[i].getAttribute('data-auth-target') === target);
+    }
+    for (var j = 0; j < panels.length; j++) {
+      panels[j].classList.toggle('is-hidden', panels[j].getAttribute('data-auth-panel') !== target);
+    }
+  }
+
+  function openAuthModal(target) {
+    switchAuthPanel(target || 'login');
+    authModal.classList.add('is-active');
+    document.body.classList.add('modal-open');
+  }
+
+  function closeAuthModal() {
+    authModal.classList.remove('is-active');
+    document.body.classList.remove('modal-open');
+  }
+
+  var openTriggers = document.querySelectorAll('.js-open-auth');
+  for (var i = 0; i < openTriggers.length; i++) {
+    openTriggers[i].addEventListener('click', function (e) {
+      e.preventDefault();
+      openAuthModal(this.getAttribute('data-auth-target') || 'login');
+    });
+  }
+
+  var closeTriggers = authModal.querySelectorAll('.js-close-auth, .modal-background');
+  for (var j = 0; j < closeTriggers.length; j++) {
+    closeTriggers[j].addEventListener('click', closeAuthModal);
+  }
+
+  var tabs = authModal.querySelectorAll('.auth-tab');
+  for (var k = 0; k < tabs.length; k++) {
+    tabs[k].addEventListener('click', function () {
+      switchAuthPanel(this.getAttribute('data-auth-target'));
+    });
+  }
+
+  document.addEventListener('keydown', function (event) {
+    if (event.key === 'Escape') {
+      closeAuthModal();
+    }
+  });
+
+  {% if auth_modal == 'register' %}
+  openAuthModal('register');
+  {% elif auth_modal == 'login' %}
+  openAuthModal('login');
+  {% endif %}
+})();
+</script>
 </body>
 </html>

--- a/web/index/views.py
+++ b/web/index/views.py
@@ -15,12 +15,16 @@ from Kunlun_M.settings import TITLE, DESCRIPTION, IS_OPEN_REGISTER
 
 base = {
         "title": TITLE,
-        "description": DESCRIPTION
+        "description": DESCRIPTION,
+        "is_open_register": IS_OPEN_REGISTER
     }
 
 
 def index(req):
-    return render(req, 'index.html', base)
+    auth_modal = req.GET.get('auth', '')
+    context = dict(base)
+    context['auth_modal'] = auth_modal
+    return render(req, 'index.html', context)
 
 
 def signup(req):
@@ -41,12 +45,12 @@ def signup(req):
                 auth.login(req, user)
                 return redirect('index:index')
             else:
-                return redirect('index:register')
+                return redirect('/?auth=register')
         else:
             messages.add_message(req, messages.ERROR, form.errors)
-            return render(req, 'register.html', base)
+            return redirect('/?auth=register')
     else:
-        return render(req, 'register.html', base)
+        return redirect('/?auth=register')
 
 
 def signin(req):
@@ -61,9 +65,9 @@ def signin(req):
             return redirect('index:index')
         else:
             messages.add_message(req, messages.ERROR, "Username or Password is incorrect.")
-            return redirect('index:login')
+            return redirect('/?auth=login')
     else:
-        return render(req, 'login.html', base)
+        return redirect('/?auth=login')
 
 
 def logout(req):


### PR DESCRIPTION
### Motivation
- 提升 web 模式首页视觉与交互体验，使首屏更现代、有层次，并简化登录/注册操作路径。
- 将分散的登录/注册页面统一为首页弹窗以减少跳转并在同一处展示错误信息。

### Description
- 重构 `templates/index.html`，引入全新 landing 布局（渐变 Hero、双栏说明、CTA 按钮）并新增认证 Modal（登录/注册 tab、消息展示、遮罩/Esc 关闭、Tab 切换）。
- 在 `static/css/default.css` 中新增 landing 与 auth modal 的样式、响应式调整和遮罩开关样式。 
- 修改 `web/index/views.py`：在首页上下文注入 `is_open_register` 与 `auth_modal`，并将对 `GET /login/` 与 `GET /register/` 的访问改为重定向回首页并通过 `?auth=login|register` 自动打开对应弹窗，登录/注册失败也重定向回首页以在弹窗中显示错误信息。
- 保留表单 POST 路径不变，前端按钮统一触发弹窗并提交到原有路由以兼容后端逻辑。

### Testing
- 运行 `python -m py_compile web/index/views.py`，语法检查通过（成功）。
- 运行 `python kunlun.py -h`，主程序帮助输出正常（成功）。
- 运行 `python manage.py check` 未能执行因为仓库中无 `manage.py`（不可用）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef0c13f1ac832d87bb8150e80831a3)