### PR TITLE
fix(web): constrain oversized topbar avatar and align username

### DIFF
--- a/static/css/dashboard-bulma.css
+++ b/static/css/dashboard-bulma.css
@@ -306,6 +306,24 @@ body.dashboard-shell {
     border-radius: 50%;
 }
 
+.navbar-nav > .user-menu .user-image {
+    width: 30px;
+    height: 30px;
+    object-fit: cover;
+    vertical-align: middle;
+}
+
+.navbar-nav > .user-menu > a > .hidden-xs {
+    margin-left: 6px;
+}
+
+.user-menu .dropdown-menu > li.user-header > img {
+    width: 72px;
+    height: 72px;
+    object-fit: cover;
+    border-radius: 50%;
+}
+
 .control-sidebar,
 .control-sidebar-bg {
     display: none !important;


### PR DESCRIPTION
### Motivation
- The top navigation bar could be distorted when the user avatar image rendered at its original large dimensions, causing layout stretching and misalignment.

### Description
- Add CSS rules in `static/css/dashboard-bulma.css` to set explicit dimensions and `object-fit: cover` for the header avatar to prevent it from overflowing the header. 
- Add left margin between the avatar and username in the header trigger to improve spacing. 
- Constrain the dropdown profile avatar size to 72x72 with `object-fit: cover` to avoid stretching the dropdown layout.

### Testing
- Ran `python3 -m pytest -q`, which completed successfully with `72 passed` and no test failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1860c6c4832dba55fcd06b8783c4)