### PR TITLE
fix: improve homepage navbar text contrast

### DIFF
--- a/static/css/default.css
+++ b/static/css/default.css
@@ -19,6 +19,25 @@ body.modal-open {
     background: radial-gradient(circle at top right, #4a6bff, #20163c 60%, #0b1221);
 }
 
+.landing-hero .navbar-item,
+.landing-hero .navbar-link {
+    color: rgba(237, 242, 255, 0.92);
+}
+
+.landing-hero .navbar-item:hover,
+.landing-hero .navbar-item:focus,
+.landing-hero .navbar-link:hover,
+.landing-hero .navbar-link:focus,
+.landing-hero .navbar-item.is-active {
+    color: #ffffff;
+    background-color: rgba(255, 255, 255, 0.1);
+}
+
+.landing-hero .navbar-brand h3,
+.landing-hero .navbar-end h3 {
+    color: #f8fbff;
+}
+
 .landing-title {
     font-size: 3rem;
     letter-spacing: .5px;


### PR DESCRIPTION
### Motivation
- The landing page navbar text and brand/user labels had low contrast against the dark radial-gradient background, making navigation items hard to read.

### Description
- Add CSS rules in `static/css/default.css` to set brighter default text color for `.landing-hero .navbar-item` and `.landing-hero .navbar-link`, and add hover/focus/active states with white text and a translucent highlight background; also set bright color for brand and username headers in the landing header.

### Testing
- Ran `git diff --check` and verified no style or whitespace issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1b3d7368832d8b3ec9081a8db081)