### PR TITLE
Fix user dropdown footer button alignment in dashboard header

### DIFF
--- a/templates/dashboard/base.html
+++ b/templates/dashboard/base.html
@@ -97,11 +97,13 @@ scratch. This page gets rid of all links and provides the needed markup only.
               </li>
               <!-- Menu Footer-->
               <li class="user-footer user-footer-modern">
-                <div class="pull-left">
-                  <a href="{% url 'dashboard:userinfo' %}" class="btn btn-default btn-flat btn-modern-quiet">Profile</a>
-                </div>
-                <div class="pull-right">
-                  <a href="{% url 'index:logout' %}" class="btn btn-default btn-flat">Sign out</a>
+                <div class="row">
+                  <div class="col-xs-6">
+                    <a href="{% url 'dashboard:userinfo' %}" class="btn btn-default btn-flat btn-modern-quiet btn-block text-center">Profile</a>
+                  </div>
+                  <div class="col-xs-6">
+                    <a href="{% url 'index:logout' %}" class="btn btn-default btn-flat btn-block text-center">Sign out</a>
+                  </div>
                 </div>
               </li>
             </ul>


### PR DESCRIPTION
### Motivation
- Prevent misalignment and uneven sizing of the `Profile` / `Sign out` buttons in the top-right user dropdown by replacing the float-based layout with a responsive grid so the buttons render consistently in narrow dropdowns.

### Description
- Replace the `pull-left`/`pull-right` footer layout with a two-column grid (`<div class="row"><div class="col-xs-6">…</div>…</div>`) in `templates/dashboard/base.html`.
- Make both `Profile` and `Sign out` use `btn-block text-center` so each action is full-width and the text is centered.

### Testing
- Inspected the modified template with `nl -ba templates/dashboard/base.html | sed -n '90,120p'` and confirmed the intended markup change, and reviewed the diff with `git diff -- templates/dashboard/base.html`, both showing the expected updates (success).
- No automated unit tests were applicable for this visual/template-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1c49bc18832d81851072dffae146)