### PR TITLE
style: 提升首页大标题可读性并精简文案

### DIFF
--- a/static/css/default.css
+++ b/static/css/default.css
@@ -41,6 +41,8 @@ body.modal-open {
 .landing-title {
     font-size: 3rem;
     letter-spacing: .5px;
+    color: #f3f6ff !important;
+    text-shadow: 0 4px 18px rgba(0, 0, 0, 0.3);
 }
 
 .landing-subtitle {
@@ -52,9 +54,11 @@ body.modal-open {
     background: rgba(255, 255, 255, 0.08);
     border: 1px solid rgba(255, 255, 255, 0.12);
     border-radius: 14px;
-    padding: 16px 18px;
+    padding: 12px 16px;
     color: #eff2ff;
     max-width: 680px;
+    font-size: 20px;
+    font-weight: 600;
 }
 
 .landing-badge {

--- a/templates/index.html
+++ b/templates/index.html
@@ -77,10 +77,10 @@
             {{ title }}
           </p>
           <p class="subtitle landing-subtitle">
-            面向代码安全审计的现代化扫描平台
+            代码安全审计平台
           </p>
           <div class="content landing-content">
-            {{ description }}
+            专注静态代码审计与供应链风险识别
           </div>
           <div class="landing-actions">
             {% if user.is_authenticated %}
@@ -103,9 +103,8 @@
           <div class="landing-panel">
             <h4>为什么选择 {{ title }}</h4>
             <ul>
-              <li><i class="fa fa-check-circle"></i> 多语言规则引擎，快速发现高危漏洞</li>
-              <li><i class="fa fa-check-circle"></i> Web 页面与任务流深度整合，低学习成本</li>
-              <li><i class="fa fa-check-circle"></i> 支持项目、依赖、供应链多维安全视图</li>
+              <li><i class="fa fa-check-circle"></i> 多语言规则引擎，快速识别高危风险</li>
+              <li><i class="fa fa-check-circle"></i> 项目与依赖安全一体化管理</li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- 解决首页 Hero 区域大标题与背景颜色接近、可读性差的问题，并响应对页面文案过多需要简化的反馈。 

### Description
- 在 `static/css/default.css` 中为 `.landing-title` 增加更亮的文字颜色和阴影并微调 `.landing-content` 的内边距与字号与字重以提升可读性。 
- 在 `templates/index.html` 中精简主视觉文案：将副标题改为“代码安全审计平台”，将说明改为“专注静态代码审计与供应链风险识别”，并将右侧优势列表从 3 条精简为 2 条并简化表述。 

### Testing
- 尝试运行 `python manage.py check`，该命令失败因为仓库中不存在 `manage.py`。 
- 运行 `rg --files -g 'manage.py'` 来确认仓库中没有 `manage.py`，命令执行成功且未找到文件。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1d96e44c832d83e65a05afd149c1)