### PR TITLE
Fix Prism number token style conflict with Bulma

### DIFF
--- a/static/css/prism.css
+++ b/static/css/prism.css
@@ -77,6 +77,19 @@ pre[class*="language-"] {
 	color: #ae81ff;
 }
 
+/* Prevent Bulma's `.number` component style from overriding Prism numeric tokens */
+code[class*="language-"] .token.number,
+pre[class*="language-"] .token.number {
+	background: transparent;
+	border-radius: 0;
+	display: inline;
+	height: auto;
+	margin: 0;
+	min-width: 0;
+	padding: 0;
+	vertical-align: baseline;
+}
+
 .token.selector,
 .token.attr-name,
 .token.string,
@@ -214,4 +227,3 @@ pre[class*="language-"].line-numbers > code {
 			padding-right: 0.8em;
 			text-align: right;
 		}
-


### PR DESCRIPTION
### Motivation
- 修复 Bulma 的 `.number` 组件样式污染 Prism 代码块中 `.token.number` 导致数字以带白底圆角徽章显示的问题。

### Description
- 在 `static/css/prism.css` 中新增针对 `code[class*="language-"] .token.number` 和 `pre[class*="language-"] .token.number` 的样式覆盖，重置 `background`、`border-radius`、`display`、`padding` 等盒模型属性以恢复数字为行内代码显示且保留原有高亮颜色。

### Testing
- 使用 `nl -ba static/css/prism.css | sed -n '68,110p'` 静态查看并确认覆盖规则已插入且仅影响 Prism 代码块中的数字 token，并且无其它样式或配色变动被引入。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1fc09840832d9004bd7016e835fe)