### PR TITLE
fix: normalize code-block numeric token styles

### DIFF
--- a/static/css/prism.css
+++ b/static/css/prism.css
@@ -80,10 +80,15 @@ pre[class*="language-"] {
 /* Prevent Bulma's `.number` component style from overriding Prism numeric tokens */
 code[class*="language-"] .token.number,
 pre[class*="language-"] .token.number {
-	background: transparent;
+	align-items: baseline;
+	background: transparent !important;
+	background-color: transparent !important;
 	border-radius: 0;
 	display: inline;
+	font-size: inherit;
 	height: auto;
+	justify-content: flex-start;
+	line-height: inherit;
 	margin: 0;
 	min-width: 0;
 	padding: 0;


### PR DESCRIPTION
### Motivation
- Bulma's `.number` utility was leaking into Prism code blocks causing numeric tokens to render as rounded badges instead of inline numbers.
- Reset numeric token layout and typographic properties so code block numbers display like normal inline text.

### Description
- Update `static/css/prism.css` to reset Prism numeric tokens under `code[class*="language-"] .token.number` and `pre[class*="language-"] .token.number`.
- Add `align-items: baseline`, `background: transparent !important`, `background-color: transparent !important`, `font-size: inherit`, `justify-content: flex-start`, and `line-height: inherit` to prevent Bulma overrides.
- Keep the change scoped to Prism selectors so Bulma's `.number` component is not altered globally.

### Testing
- Applied the patch and committed the change successfully with `git status --short` and `git commit` showing the update.
- Ran `git diff --check` to verify there are no whitespace or diff errors and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef217fe5f4832db9da3039bfada1a6)