### PR TITLE
Improve PHP SQL variable extraction: handle missing semicolons and statement boundaries, fix#2

### DIFF
--- a/rules/php/CVI_1004.py
+++ b/rules/php/CVI_1004.py
@@ -31,7 +31,8 @@ class CVI_1004():
 
         # 部分配置
         self.match_mode = "vustomize-match"
-        self.match = r"([\"']+\s*(select|SELECT|insert|INSERT|update|UPDATE)\s+([^;]\s*)(.*)\$(.+?)['\"]+(.+?)?;)"
+        # 兼容无分号的写法（例如某些模板/拼接场景），末尾分号改为可选
+        self.match = r"([\"']+\s*(select|SELECT|insert|INSERT|update|UPDATE)\s+([^;]\s*)(.*)\$(.+?)['\"]+(.+?)?;?)"
 
         # for solidity
         self.match_name = None
@@ -52,6 +53,55 @@ class CVI_1004():
         :return: 
         """
         sql_sen = regex_string[0][0]
+
+        # 先定位 SQL 关键字，再向后截取“当前语句”的片段（到首个非字符串内分号为止）
+        # 这样既能避免把 else 分支等后续代码误算进来，也能保留字符串拼接中的变量。
+        # 例如：
+        #   "SELECT ..." . $where . " ORDER BY " . $order . ";"
+        # 会保留 $where/$order；而不会误带上后续语句中的 $plan 等变量。
+        sql_start_match = re.search(r"(select|insert|update)\b", sql_sen, re.I)
+        if sql_start_match:
+            start = sql_start_match.start()
+            quote_start = max(sql_sen.rfind('"', 0, start), sql_sen.rfind("'", 0, start))
+            if quote_start != -1:
+                start = quote_start
+            sql_sen = sql_sen[start:]
+
+            quote = None
+            escaped = False
+            stmt_end = None
+
+            for index, char in enumerate(sql_sen):
+                if quote:
+                    if escaped:
+                        escaped = False
+                        continue
+                    if char == '\\':
+                        escaped = True
+                        continue
+                    if char == quote:
+                        quote = None
+                    continue
+
+                if char in ("'", '"'):
+                    quote = char
+                    continue
+
+                if char == ';':
+                    stmt_end = index + 1
+                    break
+
+                # fallback: 没有分号时，遇到明显的语句边界也结束
+                if sql_sen.startswith('} else', index) or sql_sen.startswith(' else ', index):
+                    stmt_end = index
+                    break
+                if sql_sen.startswith('?>', index):
+                    stmt_end = index
+                    break
+
+            if stmt_end is not None:
+                sql_sen = sql_sen[:stmt_end]
+
         reg = r"\$\w+"
         if re.search(reg, sql_sen, re.I):
 

--- a/tests/test_cvi_1004.py
+++ b/tests/test_cvi_1004.py
@@ -1,0 +1,53 @@
+import re
+
+from rules.php.CVI_1004 import CVI_1004
+
+
+def test_cvi_1004_extracts_all_sql_variables_in_assignment():
+    rule = CVI_1004()
+    code = (
+        '$query  = "SELECT id, name, inserted, size FROM products WHERE size = '
+        '\'${size}\' ORDER BY $order LIMIT $limit, $offset;";'
+    ).replace('${size}', '$size')
+
+    matched = re.findall(rule.match, code)
+    assert matched
+    assert rule.main(matched) == ['$size', '$order', '$limit', '$offset']
+
+
+def test_cvi_1004_does_not_leak_variables_from_non_sql_branches():
+    rule = CVI_1004()
+    code = (
+        "if ($getInfo['expire']>time()) {$plan = $odb -> query(\"SELECT `plans`.`name` "
+        "FROM `users`, `plans` WHERE `plans`.`ID` = `users`.`membership` AND "
+        "`users`.`ID` = '$id'\") -> fetchColumn(0);} else {$plan='No membership';}"
+    )
+
+    matched = re.findall(rule.match, code)
+    assert matched
+    assert rule.main(matched) == ['$id']
+
+
+def test_cvi_1004_keeps_variables_from_sql_concatenation():
+    rule = CVI_1004()
+    code = (
+        '$sql = "SELECT id, name FROM products WHERE 1=1 " . $where . '
+        '" ORDER BY " . $order . ";";'
+    )
+
+    matched = re.findall(rule.match, code)
+    assert matched
+    assert rule.main(matched) == ['$where', '$order']
+
+
+def test_cvi_1004_handles_sql_without_semicolon():
+    rule = CVI_1004()
+    code = (
+        "if ($getInfo['expire']>time()) {$plan = $odb -> query(\"SELECT `plans`.`name` "
+        "FROM `users`, `plans` WHERE `users`.`ID` = '$id'\") -> fetchColumn(0)} "
+        "else {$plan='No membership';}"
+    )
+
+    matched = re.findall(rule.match, code)
+    assert matched
+    assert rule.main(matched) == ['$id']


### PR DESCRIPTION
### Motivation
- Prevent non-SQL code (e.g. `else` branches) from being included when extracting variables from SQL string expressions.
- Support SQL expressions that omit a trailing semicolon as seen in some templates or concatenation patterns.
- Preserve concatenated variables inside SQL strings (e.g. `"..." . $where . " ..."`) while avoiding bleed into following statements.

### Description
- Relaxed the main match regex by making the trailing semicolon optional in `self.match` (changed to allow `;?`).
- Added logic in `main` to locate the SQL keyword position, expand to the enclosing string start, and then scan forward handling quoted substrings and escape sequences to find the statement end.
- Implemented early-stopping heuristics for statement boundaries such as `else` branches and PHP close tag `?>` so that only the current SQL fragment is analyzed.
- Continued extraction of variable tokens using the existing regex `\$\w+`, and added a new test module `tests/test_cvi_1004.py` with coverage for assignments, concatenation, absence of semicolon, and avoiding non-SQL branches.

### Testing
- Ran the new unit test file with `pytest tests/test_cvi_1004.py` and all tests passed.
- The tests cover SQL extraction from assignment strings, concatenated SQL pieces, SQL without a trailing semicolon, and ensuring variables from non-SQL branches are not included.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef29ad8044832db4ac42a7bb36041e)