### PR TITLE
feat(plugin): expand php_unserialize_chain_tools entrypoint and CTF sink detection

### DIFF
--- a/core/plugins/phpunserializechain/main.py
+++ b/core/plugins/phpunserializechain/main.py
@@ -78,9 +78,43 @@ class PhpUnSerChain(BasePluginClass):
         self.main()
 
     def main(self):
-
-        self.get_destruct()
+        self.get_unserialize_magic_method()
         # self.get_any_methodcall("YvGvAn", (), isnew=True)
+
+    def get_unserialize_magic_method(self):
+        """
+        从反序列化可触发的魔术方法作为入口寻找链，而不是依赖显式 unserialize 调用点。
+        """
+        unserialize_entry_methods = [
+            '__destruct', '__wakeup', '__toString', '__invoke', '__get',
+            '__set', '__call', '__callStatic', '__isset', '__unset'
+        ]
+
+        for entry_method in unserialize_entry_methods:
+            method_prefix = 'Method-{}'.format(entry_method)
+            method_nodes = self.dataflow_db.objects.filter(
+                node_type='newMethod',
+                source_node__startswith=method_prefix
+            )
+
+            for node in method_nodes:
+                unserchain = [node]
+                class_locate = node.node_locate
+
+                new_locate = node.node_locate + '.' + node.source_node
+                method_body_nodes = self.dataflow_db.objects.filter(node_locate__startswith=new_locate)
+
+                logger.info("[PhpUnSerChain] New Chain Start in {} in {}".format(method_prefix, node.node_locate))
+                status = self.deep_search_chain(method_body_nodes, class_locate, unserchain)
+
+                if status:
+                    logger.info("[PhpUnSerChain] New Source {}{} in {}".format(method_prefix, node.sink_node, node.node_locate))
+
+                    for unsernode in unserchain:
+                        logger.info("{}".format(unsernode.node_locate.ljust(100, ' ')))
+                        logger_console.warn("{}   {}{}".format(unsernode.node_type.ljust(30, ' '), unsernode.source_node,
+                                                               self.deep_get_node_name(unsernode.sink_node)))
+                    logger.info("[PhpUnSerChain] UnSerChain is available.")
 
     def get_destruct(self):
 
@@ -421,6 +455,9 @@ class PhpUnSerChain(BasePluginClass):
                                 'call_user_func_array': [0],
                                 }
 
+        if self.check_flag_sink(node):
+            return True
+
         if node.node_type == 'FunctionCall' and node.source_node in self.danger_function:
             sink_node = ast.literal_eval(node.sink_node) if node.sink_node.startswith('(') else (node.sink_node)
 
@@ -454,6 +491,26 @@ class PhpUnSerChain(BasePluginClass):
                             return False
 
                         return True
+
+        return False
+
+    def check_flag_sink(self, node):
+        """
+        CTF 场景中，将输出 flag（或类似敏感字符串）的行为也作为 sink。
+        """
+        flag_pattern = re.compile(r'flag|ctf\{|\$flag|key|secret', re.I)
+
+        if node.node_type in self.special_function_multi and node.source_node == 'echo':
+            sink_node = self.deep_get_node_name(node.sink_node)
+            if flag_pattern.search(sink_node):
+                logger.debug("[PhpUnSerChain] Found CTF flag-like sink in echo: {}".format(sink_node))
+                return True
+
+        if node.node_type == 'FunctionCall' and node.source_node in ['printf', 'print_r', 'var_dump', 'die', 'exit']:
+            sink_node = self.deep_get_node_name(node.sink_node)
+            if flag_pattern.search(sink_node):
+                logger.debug("[PhpUnSerChain] Found CTF flag-like sink in {}: {}".format(node.source_node, sink_node))
+                return True
 
         return False
 


### PR DESCRIPTION
### Motivation
- The plugin previously focused on `__destruct` as the primary entry for generating PHP unserialize gadget chains, which misses cases where objects are triggered via other magic methods or when there is no explicit `unserialize` call. 
- For CTF use-cases, leaking a `flag`-like string (e.g. `ctf{...}`, `$flag`, `key`, `secret`) should be treated as a valid sink when generating/guiding deserialization chains.

### Description
- Add `get_unserialize_magic_method()` and call it from `main()` to iterate a broader set of unserialize-triggerable magic methods (`__destruct`, `__wakeup`, `__toString`, `__invoke`, `__get`, `__set`, `__call`, `__callStatic`, `__isset`, `__unset`) as chain entry points. 
- Keep the existing `get_destruct()` intact but no longer use it as the sole default entry; the new method performs the unified traversal and prints discovered chains similarly to the previous behavior. 
- Add `check_flag_sink()` to detect CTF-style sinks by matching a configurable flag-like regex and inspecting common output sinks (including `echo`, `printf`, `print_r`, `var_dump`, `die`, `exit`). 
- Integrate `check_flag_sink()` into `check_danger_sink()` so flag-like outputs are treated as valid sinks alongside existing dangerous function checks.

### Testing
- Compiled the modified file with `python3 -m py_compile core/plugins/phpunserializechain/main.py` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f181ebcdd4832dac60be0ad98b2012)