### PR TITLE
fix(plugin): ensure php_unserialize_chain_tools writes PoC output

### DIFF
--- a/core/plugins/phpunserializechain/main.py
+++ b/core/plugins/phpunserializechain/main.py
@@ -88,6 +88,7 @@ class PhpUnSerChain(BasePluginClass):
 
     def main(self):
         self.get_unserialize_magic_method()
+        self.generate_poc_files()
         # self.get_any_methodcall("YvGvAn", (), isnew=True)
 
     def get_unserialize_magic_method(self):
@@ -114,6 +115,8 @@ class PhpUnSerChain(BasePluginClass):
                 method_body_nodes = self.dataflow_db.objects.filter(node_locate__startswith=new_locate)
 
                 logger.info("[PhpUnSerChain] New Chain Start in {} in {}".format(method_prefix, node.node_locate))
+                self.current_chain_relations = []
+                self.current_chain_properties = []
                 status = self.deep_search_chain(method_body_nodes, class_locate, unserchain)
 
                 if status:
@@ -124,6 +127,7 @@ class PhpUnSerChain(BasePluginClass):
                         logger_console.warn("{}   {}{}".format(unsernode.node_type.ljust(30, ' '), unsernode.source_node,
                                                                self.deep_get_node_name(unsernode.sink_node)))
                     logger.info("[PhpUnSerChain] UnSerChain is available.")
+                    self.record_available_chain(unserchain, self.current_chain_relations, self.current_chain_properties)
 
     def get_destruct(self):
 


### PR DESCRIPTION
### Motivation
- Discovered deserialization chains were not being persisted to disk even when an output path was provided, because the plugin did not record chains in the main discovery path and did not invoke PoC generation after analysis.

### Description
- Call `generate_poc_files()` from `main()` so discovered chains are rendered to files (adds file generation to the plugin run flow).
- Reset `self.current_chain_relations` and `self.current_chain_properties` before analyzing each magic-method entry in `get_unserialize_magic_method()` to avoid cross-chain contamination.
- Persist successful chains found in `get_unserialize_magic_method()` by calling `record_available_chain(...)` when a full chain is discovered.
- Changes are applied in `core/plugins/phpunserializechain/main.py` and adjust the plugin’s main discovery-to-generation pipeline.

### Testing
- Ran `python -m py_compile core/plugins/phpunserializechain/main.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a93a5654832d8087a5f96f139a75)