### PR TITLE
CI: centralize Kunlun scan configs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,19 +1,2 @@
-stages:
-  - security
-
-kunlun_ci_scan:
-  stage: security
-  image: python:3.11
-  variables:
-    KUNLUN_FAIL_ON: "high"
-    KUNLUN_INCLUDE_UNCONFIRM: "0"
-    KUNLUN_WITH_VENDOR: "0"
-  before_script:
-    - python -m pip install -r requirements.txt
-  script:
-    - python tools/ci_scan.py --target . --output artifacts/kunlun-ci.json --fail-on "${KUNLUN_FAIL_ON}"
-  artifacts:
-    when: always
-    paths:
-      - artifacts/kunlun-ci.json
-
+include:
+  - local: 'ci/gitlab/kunlun-ci.yml'

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,10 @@
+## CI 配置文件目录
+
+本目录用于集中存放 Kunlun-M 的 CI 示例配置，便于在其它项目中复用与维护。
+
+注意：不同平台对配置文件路径有硬性要求：
+
+- GitHub Actions 必须位于 `.github/workflows/*.yml`
+- GitLab CI 默认入口必须是仓库根目录的 `.gitlab-ci.yml`（可通过 include 引入本目录文件）
+- Jenkins 默认入口通常是仓库根目录的 `Jenkinsfile`（也可以在 Job 配置里把 Script Path 指向本目录文件）
+

--- a/ci/github-actions/kunlun-scan.yml
+++ b/ci/github-actions/kunlun-scan.yml
@@ -1,0 +1,29 @@
+name: kunlun-ci-scan
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    env:
+      KUNLUN_FAIL_ON: high
+      KUNLUN_INCLUDE_UNCONFIRM: "0"
+      KUNLUN_WITH_VENDOR: "0"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+      - name: Run KunLun CI scan
+        run: python tools/ci_scan.py --target . --output artifacts/kunlun-ci.json --fail-on "${KUNLUN_FAIL_ON}"
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: kunlun-ci-report
+          path: artifacts/kunlun-ci.json
+

--- a/ci/gitlab/kunlun-ci.yml
+++ b/ci/gitlab/kunlun-ci.yml
@@ -1,0 +1,19 @@
+stages:
+  - security
+
+kunlun_ci_scan:
+  stage: security
+  image: python:3.11
+  variables:
+    KUNLUN_FAIL_ON: "high"
+    KUNLUN_INCLUDE_UNCONFIRM: "0"
+    KUNLUN_WITH_VENDOR: "0"
+  before_script:
+    - python -m pip install -r requirements.txt
+  script:
+    - python tools/ci_scan.py --target . --output artifacts/kunlun-ci.json --fail-on "${KUNLUN_FAIL_ON}"
+  artifacts:
+    when: always
+    paths:
+      - artifacts/kunlun-ci.json
+

--- a/ci/jenkins/Jenkinsfile
+++ b/ci/jenkins/Jenkinsfile
@@ -1,0 +1,26 @@
+pipeline {
+  agent any
+  environment {
+    KUNLUN_FAIL_ON = 'high'
+    KUNLUN_INCLUDE_UNCONFIRM = '0'
+    KUNLUN_WITH_VENDOR = '0'
+  }
+  stages {
+    stage('Install') {
+      steps {
+        sh 'python -m pip install -r requirements.txt'
+      }
+    }
+    stage('Scan') {
+      steps {
+        sh 'python tools/ci_scan.py --target . --output artifacts/kunlun-ci.json --fail-on "${KUNLUN_FAIL_ON}"'
+      }
+    }
+  }
+  post {
+    always {
+      archiveArtifacts artifacts: 'artifacts/kunlun-ci.json', allowEmptyArchive: true
+    }
+  }
+}
+

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -94,8 +94,8 @@ python tools/ci_scan.py --target . --output artifacts/kunlun-ci.json --fail-on h
 
 ## CI 配置示例
 
-- GitHub Actions：见 [kunlun-scan.yml](file:///workspace/.github/workflows/kunlun-scan.yml)
-- GitLab CI：见 [.gitlab-ci.yml](file:///workspace/.gitlab-ci.yml)
-- Jenkins：见 [Jenkinsfile](file:///workspace/Jenkinsfile)
+- GitHub Actions：见 [kunlun-scan.yml](file:///workspace/ci/github-actions/kunlun-scan.yml)（仓库内实际运行位置仍需放在 `.github/workflows/`）
+- GitLab CI：见 [kunlun-ci.yml](file:///workspace/ci/gitlab/kunlun-ci.yml)（根目录 `.gitlab-ci.yml` 已通过 include 引用）
+- Jenkins：见 [Jenkinsfile](file:///workspace/ci/jenkins/Jenkinsfile)（可在 Jenkins Job 中配置 Script Path 指向该文件）
  
 说明：仓库内的 `.travis.yml` 属于历史配置，不作为当前 CI 扫描驱动的维护示例。


### PR DESCRIPTION
此次 PR 将 Kunlun-M 的 CI 扫描配置集中到 ci/ 目录，便于跨项目复用与维护，并统一各平台产出 artifacts/kunlun-ci.json 报告的方式。

变更要点：
- .gitlab-ci.yml 精简为 include 引用 ci/gitlab/kunlun-ci.yml
- 新增 GitHub Actions 示例：ci/github-actions/kunlun-scan.yml
- 新增 Jenkins 示例：ci/jenkins/Jenkinsfile
- 新增 ci/README.md 说明目录用途与各平台默认入口约束
- docs/ci.md 更新示例链接与使用说明
