### PR TITLE
完善 tamper 框架配置：修复 bug + 补充 filter/sink/source

### DIFF
--- a/rules/tamper/go/_base.py
+++ b/rules/tamper/go/_base.py
@@ -27,7 +27,6 @@ IS_REPAIR = {
     "html.Escape": [8003, 8008],
     "template.HTMLEscapeString": [8003, 8008],
     "template.JSEscapeString": [8003, 8008],
-    "template.HTML": [8003, 8008],
     "json.Marshal": [8003, 8008],
     "json.MarshalIndent": [8003, 8008],
     "json.HTMLEscape": [8003, 8008],

--- a/rules/tamper/go/beego.py
+++ b/rules/tamper/go/beego.py
@@ -7,6 +7,15 @@ DEPENDENCIES = {'gomod': ['github.com/astaxie/beego', 'github.com/beego/beego']}
 
 def detect(project_dir, language='go'):
     """检测是否为 Beego 项目"""
+    go_mod = os.path.join(project_dir, 'go.mod')
+    if os.path.isfile(go_mod):
+        try:
+            with open(go_mod, 'r', encoding='utf-8') as f:
+                content = f.read()
+                if 'beego' in content:
+                    return True
+        except IOError:
+            pass
     return False
 
 
@@ -18,9 +27,19 @@ CONTROLLED_SOURCES = [
     'c.GetStrings',
     'c.Input',
     'c.Ctx.Input.Query',
+    'c.Ctx.Input.Param',
+    'c.Ctx.Input.Header',
+    'c.Ctx.Input.Cookie',
+    'c.Ctx.Input.RequestBody',
 ]
 
 EXTRA_SINKS = [
     ("beego.AppConfig.String(", []),
     ("c.Ctx.Output.Body(", [8008]),
+    ("c.Ctx.WriteString(", [8003, 8008]),
+    ("c.ServeJSON(", [8003, 8008]),
+    ("c.ServeXML(", [8003, 8008]),
+    ("c.ServeJSONP(", [8003, 8008]),
+    ("c.ServeFile(", [8006]),
+    ("c.Redirect(", [8013]),
 ]

--- a/rules/tamper/go/chi.py
+++ b/rules/tamper/go/chi.py
@@ -7,6 +7,15 @@ DEPENDENCIES = {'gomod': ['github.com/go-chi/chi']}
 
 def detect(project_dir, language='go'):
     """检测是否为 Chi 项目"""
+    go_mod = os.path.join(project_dir, 'go.mod')
+    if os.path.isfile(go_mod):
+        try:
+            with open(go_mod, 'r', encoding='utf-8') as f:
+                content = f.read()
+                if 'chi' in content and 'go-chi' in content:
+                    return True
+        except IOError:
+            pass
     return False
 
 
@@ -16,8 +25,20 @@ CONTROLLED_SOURCES = [
     'r.URL.Query',
     'chi.URLParam',
     'chi.URLParamFromCtx',
+    'r.FormValue',
+    'r.PostFormValue',
+    'r.Header.Get',
+    'r.Body',
+    'r.Cookies',
+    'r.Cookie',
 ]
 
 EXTRA_SINKS = [
     ("http.Redirect(", [8013]),
+    ("http.ServeFile(", [8004, 8006]),
+    ("http.FileServer(", [8006]),
+    ("w.Write(", [8003, 8008]),
+    ("fmt.Fprintf(w,", [8003, 8008]),
+    ("template.Execute(", [8003, 8008]),
+    ("json.NewEncoder(w).Encode(", [8003, 8008]),
 ]

--- a/rules/tamper/go/echo.py
+++ b/rules/tamper/go/echo.py
@@ -7,6 +7,15 @@ DEPENDENCIES = {'gomod': ['github.com/labstack/echo']}
 
 def detect(project_dir, language='go'):
     """检测是否为 Echo 项目"""
+    go_mod = os.path.join(project_dir, 'go.mod')
+    if os.path.isfile(go_mod):
+        try:
+            with open(go_mod, 'r', encoding='utf-8') as f:
+                content = f.read()
+                if 'echo' in content and 'labstack' in content:
+                    return True
+        except IOError:
+            pass
     return False
 
 
@@ -18,10 +27,22 @@ CONTROLLED_SOURCES = [
     'c.FormValue',
     'c.Request.FormValue',
     'c.QueryString',
+    'c.Cookies',
+    'c.Cookie',
+    'c.RealIP',
+    'c.IP',
+    'c.Request().Body',
 ]
 
 EXTRA_SINKS = [
     ("c.HTML(", [8008]),
     ("c.File(", [8006]),
     ("c.Redirect(", [8013]),
+    ("c.JSON(", [8003, 8008]),
+    ("c.JSONPretty(", [8003, 8008]),
+    ("c.String(", [8003, 8008]),
+    ("c.XML(", [8003, 8008]),
+    ("c.Blob(", [8004, 8006]),
+    ("c.Attachment(", [8004, 8006]),
+    ("c.Stream(", [8004]),
 ]

--- a/rules/tamper/go/fiber.py
+++ b/rules/tamper/go/fiber.py
@@ -7,6 +7,15 @@ DEPENDENCIES = {'gomod': ['github.com/gofiber/fiber']}
 
 def detect(project_dir, language='go'):
     """检测是否为 Fiber 项目"""
+    go_mod = os.path.join(project_dir, 'go.mod')
+    if os.path.isfile(go_mod):
+        try:
+            with open(go_mod, 'r', encoding='utf-8') as f:
+                content = f.read()
+                if 'fiber' in content and 'gofiber' in content:
+                    return True
+        except IOError:
+            pass
     return False
 
 
@@ -18,10 +27,22 @@ CONTROLLED_SOURCES = [
     'c.FormValue',
     'c.Body',
     'c.Get',
+    'c.Cookies',
+    'c.Path',
+    'c.IP',
+    'c.IPs',
+    'c.Hostname',
+    'c.Protocol',
 ]
 
 EXTRA_SINKS = [
     ("c.HTML(", [8008]),
     ("c.SendFile(", [8006]),
     ("c.Redirect(", [8013]),
+    ("c.JSON(", [8003, 8008]),
+    ("c.SendString(", [8003, 8008]),
+    ("c.SendStatus(", [8003, 8008]),
+    ("c.XML(", [8003, 8008]),
+    ("c.Download(", [8004, 8006]),
+    ("c.Stream(", [8004]),
 ]

--- a/rules/tamper/go/gin.py
+++ b/rules/tamper/go/gin.py
@@ -28,6 +28,13 @@ EXTRA_SINKS = [
     ("c.FileAttachment(", [8006]),
     ("c.Redirect(", [8013]),
     ("c.JSONP(", [8008]),
+    ("c.String(", [8003, 8008]),
+    ("c.JSON(", [8003, 8008]),
+    ("c.XML(", [8003, 8008]),
+    ("c.YAML(", [8003, 8008]),
+    ("c.Data(", [8003, 8008]),
+    ("c.Writer.Write(", [8003, 8008]),
+    ("c.SaveUploadedFile(", [8004, 8006]),
 ]
 
 CONTROLLED_SOURCES = [
@@ -42,4 +49,10 @@ CONTROLLED_SOURCES = [
     'ctx.Param',
     'ctx.PostForm',
     'ctx.GetHeader',
+    'c.DefaultQuery',
+    'c.DefaultPostForm',
+    'c.ShouldBindQuery',
+    'c.ShouldBindXML',
+    'c.ShouldBindYAML',
+    'c.ClientIP',
 ]

--- a/rules/tamper/java/_base.py
+++ b/rules/tamper/java/_base.py
@@ -80,7 +80,6 @@ IS_REPAIR = {
     "ESAPI.encoder().encodeForHTML": [6002, 6022],
 
     # ---- 命令注入防御 ----
-    "ProcessBuilder": [6003, 6023, 6032, 6038],
     "escapeShellArg": [6003, 6023, 6032, 6038],
 
     # ---- 路径穿越防御 ----

--- a/rules/tamper/java/mybatis.py
+++ b/rules/tamper/java/mybatis.py
@@ -7,13 +7,32 @@ DEPENDENCIES = {'pom': ['mybatis', 'mybatis-spring']}
 
 def detect(project_dir, language='java'):
     """检测是否为 MyBatis 项目"""
+    pom_path = os.path.join(project_dir, 'pom.xml')
+    if os.path.isfile(pom_path):
+        try:
+            with open(pom_path, 'r', encoding='utf-8', errors='ignore') as f:
+                content = f.read()
+                if 'mybatis' in content.lower():
+                    return True
+        except IOError:
+            pass
     return False
 
 
 FILTER_FUNCTIONS = {}
 
-CONTROLLED_SOURCES = []
+CONTROLLED_SOURCES = [
+    '@Param',
+    '@Mapper',
+]
 
 EXTRA_SINKS = [
-    ('${', [1004]),
+    ('${', [6031]),
+    # MyBatis dynamic SQL provider annotations
+    ("@SelectProvider", [6031]),
+    ("@InsertProvider", [6031]),
+    ("@UpdateProvider", [6031]),
+    ("@DeleteProvider", [6031]),
+    # SqlSession direct API
+    ("SqlSession.select", [6031]),
 ]

--- a/rules/tamper/java/spring.py
+++ b/rules/tamper/java/spring.py
@@ -12,7 +12,10 @@ def detect(project_dir, language='java'):
             or os.path.isfile(os.path.join(resources, 'application.yml')))
 
 
-FILTER_FUNCTIONS = {}
+FILTER_FUNCTIONS = {
+    # Validation annotation - validated input is safer for these CVIs
+    '@Valid': [6002, 6004, 6043],
+}
 
 EXTRA_SINKS = [
     ("jdbcTemplate.query(", [6001]),
@@ -21,6 +24,26 @@ EXTRA_SINKS = [
     ("restTemplate.getForObject(", [6006]),
     ("restTemplate.exchange(", [6006]),
     ("restTemplate.postForObject(", [6006]),
+    # Spring MVC view-related XSS sinks
+    ("ModelAndView", [6002]),
+    ("addAttribute(", [6002]),
+    # Open redirect sinks
+    ("sendRedirect(", [6015]),
+    ("RedirectView", [6015]),
+    # Additional JDBC / ORM SQL injection sinks
+    ("JdbcTemplate.queryForRowSet(", [6001]),
+    ("JdbcTemplate.batchUpdate(", [6001]),
+    ("EntityManager.createNativeQuery(", [6001]),
+    # JPA / JPQL annotation-based query sink
+    ("@Query", [6048]),
+    # Spring Expression Language injection
+    ("SpEL", [6012]),
+    # Command execution sinks
+    ("Runtime.exec(", [6003]),
+    ("ProcessBuilder", [6003]),
+    # XStream deserialization
+    ("XStream", [6044]),
+    ("XStream.fromXML(", [6044]),
 ]
 
 CONTROLLED_SOURCES = [
@@ -29,4 +52,17 @@ CONTROLLED_SOURCES = [
     '@RequestBody',
     '@RequestHeader',
     '@CookieValue',
+    # Additional Spring-controlled parameter bindings
+    '@ModelAttribute',
+    '@SessionAttributes',
+    '@RequestPart',
+    '@MatrixVariable',
+    '@AuthenticationPrincipal',
+    # Servlet API objects (request/response/session)
+    'HttpServletRequest',
+    'HttpServletResponse',
+    'HttpSession',
+    'Principal',
+    # Multipart upload source
+    'MultipartFile',
 ]

--- a/rules/tamper/java/struts2.py
+++ b/rules/tamper/java/struts2.py
@@ -10,11 +10,30 @@ def detect(project_dir, language='java'):
     return os.path.isfile(os.path.join(project_dir, 'struts.xml'))
 
 
+# Struts2 relies on the interceptor stack rather than per-function repair functions,
+# so FILTER_FUNCTIONS is intentionally left empty.
 FILTER_FUNCTIONS = {}
 
-CONTROLLED_SOURCES = []
+CONTROLLED_SOURCES = [
+    'ActionContext',
+    'ServletActionContext.getRequest',
+    'getServlet',
+]
 
 EXTRA_SINKS = [
     ("ActionContext.getContext()", [6002]),
     ("ServletActionContext.getRequest()", [6002]),
+    # OGNL-related sinks (OGNL injection)
+    ("ActionContext.getContext()", [6054]),
+    ("ValueStack.findValue(", [6054]),
+    ("ValueStack.findString(", [6054]),
+    ("OGNL", [6054]),
+    # Expression-language injection sinks
+    ("TextParseUtil.translateVariables(", [6012]),
+    # Open redirect sink
+    ("ServletActionContext.getResponse().sendRedirect(", [6015]),
+    # Struts2 dynamic method invocation
+    ("XWork2", [6056]),
+    # Freemarker SSTI / XSS sink
+    ("Freemarker", [6002]),
 ]

--- a/rules/tamper/javascript/_base.py
+++ b/rules/tamper/javascript/_base.py
@@ -58,8 +58,6 @@ IS_REPAIR = {
     # 编码/加密
     "encodeURIComponent": [3100, 3102, 3106],
     "encodeURI": [3100, 3102, 3106],
-    "crypto.createHash": [3100, 3103],
-    "Buffer.from": [3100],
 
     # 反序列化防护
     "JSON.parse": [3105],

--- a/rules/tamper/javascript/express.py
+++ b/rules/tamper/javascript/express.py
@@ -20,11 +20,28 @@ def detect(project_dir, language='javascript'):
     return False
 
 
-FILTER_FUNCTIONS = {}
+FILTER_FUNCTIONS = {
+    'express-validator': [3100, 3101, 3102, 3104],
+}
 
 EXTRA_SINKS = [
     ("res.render(", [3005]),
     ("res.redirect(", [3004]),
+    ("res.json(", [3100, 3110]),
+    ("res.send(", [3100, 3110]),
+    ("res.sendFile(", [3102, 3106]),
+    ("res.download(", [3102, 3106]),
+    ("child_process.exec(", [3101]),
+    ("child_process.spawn(", [3101]),
+    ("child_process.execSync(", [3101]),
+    ("fs.readFile(", [3102, 3106]),
+    ("fs.writeFile(", [3102]),
+    ("fs.readFileSync(", [3102, 3106]),
+    ("fetch(", [3105]),
+    ("axios.get(", [3105]),
+    ("axios.post(", [3105]),
+    ("eval(", [3103]),
+    ("new Function(", [3103]),
 ]
 
 CONTROLLED_SOURCES = [
@@ -39,4 +56,9 @@ CONTROLLED_SOURCES = [
     'req.ip',
     'req.get',
     'req.param',
+    'req.signedCookies',
+    'req.hostname',
+    'req.originalUrl',
+    'req.subdomains',
+    'req.user',
 ]

--- a/rules/tamper/javascript/fastify.py
+++ b/rules/tamper/javascript/fastify.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import json
 import os
 
 FRAMEWORK_NAME = 'Fastify'
@@ -7,6 +8,15 @@ DEPENDENCIES = {'package': ['fastify']}
 
 def detect(project_dir, language='javascript'):
     """检测是否为 Fastify 项目"""
+    pkg_path = os.path.join(project_dir, 'package.json')
+    if os.path.isfile(pkg_path):
+        try:
+            with open(pkg_path, 'r', encoding='utf-8') as f:
+                pkg = json.load(f)
+                deps = {**pkg.get('dependencies', {}), **pkg.get('devDependencies', {})}
+                return 'fastify' in deps
+        except (json.JSONDecodeError, IOError):
+            pass
     return False
 
 
@@ -17,9 +27,17 @@ CONTROLLED_SOURCES = [
     'request.body',
     'request.params',
     'request.headers',
+    'request.cookies',
+    'request.ip',
+    'request.hostname',
+    'request.protocol',
+    'request.url',
 ]
 
 EXTRA_SINKS = [
     ("reply.view(", [3005]),
     ("reply.redirect(", [3004]),
+    ("reply.send(", [3100, 3110]),
+    ("reply.file(", [3102, 3106]),
+    ("reply.download(", [3102, 3106]),
 ]

--- a/rules/tamper/javascript/koa.py
+++ b/rules/tamper/javascript/koa.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import json
 import os
 
 FRAMEWORK_NAME = 'Koa'
@@ -7,6 +8,15 @@ DEPENDENCIES = {'package': ['koa']}
 
 def detect(project_dir, language='javascript'):
     """检测是否为 Koa 项目"""
+    pkg_path = os.path.join(project_dir, 'package.json')
+    if os.path.isfile(pkg_path):
+        try:
+            with open(pkg_path, 'r', encoding='utf-8') as f:
+                pkg = json.load(f)
+                deps = {**pkg.get('dependencies', {}), **pkg.get('devDependencies', {})}
+                return 'koa' in deps
+        except (json.JSONDecodeError, IOError):
+            pass
     return False
 
 
@@ -19,9 +29,18 @@ CONTROLLED_SOURCES = [
     'ctx.request.body',
     'ctx.params',
     'ctx.request.header',
+    'ctx.ip',
+    'ctx.hostname',
+    'ctx.host',
+    'ctx.protocol',
+    'ctx.cookies.get',
+    'ctx.headers',
 ]
 
 EXTRA_SINKS = [
     ("ctx.render(", [3005]),
     ("ctx.redirect(", [3004]),
+    ("ctx.body =", [3100, 3110]),
+    ("ctx.attachment(", [3102, 3106]),
+    ("ctx.redirect(", [3109]),
 ]

--- a/rules/tamper/javascript/nestjs.py
+++ b/rules/tamper/javascript/nestjs.py
@@ -10,11 +10,29 @@ def detect(project_dir, language='javascript'):
     return os.path.isfile(os.path.join(project_dir, 'nest-cli.json'))
 
 
-FILTER_FUNCTIONS = {}
+FILTER_FUNCTIONS = {
+    'class-validator': [3100, 3101, 3102, 3104],
+    'ValidationPipe': [3100, 3101, 3102, 3104],
+}
 
-CONTROLLED_SOURCES = []
+CONTROLLED_SOURCES = [
+    '@Body',
+    '@Query',
+    '@Param',
+    '@Headers',
+    '@Req',
+    '@Request',
+    '@Ip',
+    '@Cookies',
+    '@RequestPart',
+]
 
 EXTRA_SINKS = [
     ("res.render(", [3005]),
     ("res.redirect(", [3004]),
+    ("res.json(", [3100, 3110]),
+    ("res.send(", [3100, 3110]),
+    ("res.sendFile(", [3102, 3106]),
+    ("@Redirect(", [3109]),
+    ("TypeOrm", [3104]),
 ]

--- a/rules/tamper/javascript/nextjs.py
+++ b/rules/tamper/javascript/nextjs.py
@@ -13,8 +13,23 @@ def detect(project_dir, language='javascript'):
 
 FILTER_FUNCTIONS = {}
 
-CONTROLLED_SOURCES = []
+CONTROLLED_SOURCES = [
+    'req.query',
+    'req.headers',
+    'req.body',
+    'req.cookies',
+    'context.query',
+    'context.params',
+    'searchParams',
+    'cookies()',
+]
 
 EXTRA_SINKS = [
     ("next/redirect(", [3004]),
+    ("dangerouslySetInnerHTML", [3100, 3110]),
+    ("router.push(", [3109]),
+    ("router.replace(", [3109]),
+    ("redirect(", [3109]),
+    ("fetch(", [3105]),
+    ("prisma.$queryRaw(", [3104]),
 ]

--- a/rules/tamper/php/codeigniter.py
+++ b/rules/tamper/php/codeigniter.py
@@ -11,11 +11,17 @@ def detect(project_dir, language='php'):
             or os.path.isdir(os.path.join(project_dir, 'app', 'Controllers')))
 
 
-FILTER_FUNCTIONS = {}
+FILTER_FUNCTIONS = {
+    '$this->security->xss_clean': {'safe_for': [1000, 1010]},
+    '$this->db->escape': {'safe_for': [1004]},
+    '$this->db->escape_str': {'safe_for': [1004]},
+}
 
 EXTRA_SINKS = [
     ("$this->db->query(", [1004]),
     ("->query(", [1004]),
+    ("view(", [1000]),
+    ("redirect(", [1009]),
 ]
 
 CONTROLLED_SOURCES = [
@@ -25,4 +31,6 @@ CONTROLLED_SOURCES = [
     '$this->request->getVar',
     '$this->request->getPost',
     '$this->request->getGet',
+    '$this->request->getJSON',
+    '$this->input->ip_address',
 ]

--- a/rules/tamper/php/drupal.py
+++ b/rules/tamper/php/drupal.py
@@ -14,14 +14,26 @@ FILTER_FUNCTIONS = {
     'check_plain': {'safe_for': [1000, 10001, 10002]},
     'drupal_html_class': {'safe_for': [1000]},
     'UrlHelper::stripDangerousProtocols': {'safe_for': [1000]},
+    'Xss::filter': {'safe_for': [1000, 1010]},
+    'Xss::filterAdmin': {'safe_for': [1000, 1010]},
+    'Html::escape': {'safe_for': [1000, 1010, 10001]},
 }
 
 CONTROLLED_SOURCES = [
     '\\Drupal::request()->get',
     '\\Drupal::requestStack()->getCurrentRequest()->get',
+    '\\Drupal::request()->query->get',
+    '\\Drupal::request()->request->get',
+    '$form_state->getValue',
 ]
 
 EXTRA_SINKS = [
     ('\\Drupal::database()->query', [1004]),
     ('\\Drupal::database()->select', [1004]),
+    ('->insert(', [1004]),
+    ('->update(', [1004]),
+    ('->delete(', [1004]),
+    ('file_save_data(', [1002]),
+    ('\\Drupal::httpClient(', [1005]),
+    ('->redirect(', [1009]),
 ]

--- a/rules/tamper/php/laravel.py
+++ b/rules/tamper/php/laravel.py
@@ -7,7 +7,7 @@ DEPENDENCIES = {'composer': ['laravel/framework']}
 
 def detect(project_dir, language='php'):
     """检测是否为 Laravel 项目"""
-    return (os.path.isfile(os.path.join(project_dir, 'app', 'Http', 'Kernel.py'))
+    return (os.path.isfile(os.path.join(project_dir, 'app', 'Http', 'Kernel.php'))
             or os.path.isfile(os.path.join(project_dir, 'routes', 'web.php'))
             or os.path.isfile(os.path.join(project_dir, 'artisan')))
 
@@ -16,6 +16,13 @@ FILTER_FUNCTIONS = {
     'e()': {'safe_for': [1000, 10001, 10002]},
     'csrf_field': {'safe_for': []},
     'csrf_token': {'safe_for': []},
+    # HTMLPurifier integration
+    'Purifier::clean': {'safe_for': [1000, 1010]},
+    'strip_tags': {'safe_for': [1000, 1010]},
+    # URL encoding
+    'urlencode': {'safe_for': [1005, 1006]},
+    # signed redirect is safe
+    'redirect()->signedRoute': {'safe_for': [1009]},
 }
 
 EXTRA_SINKS = [
@@ -23,6 +30,11 @@ EXTRA_SINKS = [
     ("DB::select", [1004]),
     ("DB::statement", [1004]),
     ("DB::unprepared", [1004]),
+    ("redirect(", [1009]),
+    ("view(", [1000]),
+    ("Response::json(", [1000]),
+    ("Storage::download(", [1002]),
+    ("Storage::get(", [1002]),
 ]
 
 CONTROLLED_SOURCES = [
@@ -49,4 +61,9 @@ CONTROLLED_SOURCES = [
     '$request',
     'input()',
     'old()',
+    'request()->all',
+    'request()->file',
+    'request()->bearerToken',
+    '$request->all',
+    '$request->files',
 ]

--- a/rules/tamper/php/phpbb.py
+++ b/rules/tamper/php/phpbb.py
@@ -10,6 +10,20 @@ def detect(project_dir, language='php'):
     return os.path.isdir(os.path.join(project_dir, 'phpbb'))
 
 
-FILTER_FUNCTIONS = {}
+FILTER_FUNCTIONS = {
+    '$request->variable': {'safe_for': [1000, 1001, 1004]},  # type-enforced input
+    '$this->db->sql_escape': {'safe_for': [1004]},
+}
 
-CONTROLLED_SOURCES = []
+EXTRA_SINKS = [
+    ("->sql_query(", [1004]),
+    ("->sql_build_query(", [1004]),
+    ("redirect(", [1009]),
+    ("include(", [1003]),
+]
+
+CONTROLLED_SOURCES = [
+    '$request->variable',
+    '$this->request->get_super_global',
+    '$user->data',
+]

--- a/rules/tamper/php/roundcube.py
+++ b/rules/tamper/php/roundcube.py
@@ -12,10 +12,18 @@ def detect(project_dir, language='php'):
 
 FILTER_FUNCTIONS = {
     'rcube_utils::rep_specialchars_output': {'safe_for': [1000, 10001, 10002]},
+    'rcube_html::clean': {'safe_for': [1000, 1010]},
 }
 
 CONTROLLED_SOURCES = [
     'rcube_utils::get_input_value',
     'rcube_utils::get_request_header',
     'rcube_utils::get_request_param',
+    'rcube_session::get',
+    '$OUTPUT->get_env',
+]
+
+EXTRA_SINKS = [
+    ("$DB->query(", [1004]),
+    ("rcube_utils::http_get(", [1005]),
 ]

--- a/rules/tamper/php/slim.py
+++ b/rules/tamper/php/slim.py
@@ -11,6 +11,7 @@ def detect(project_dir, language='php'):
 
 
 FILTER_FUNCTIONS = {}
+# Slim relies on _base.php standard library filter functions
 
 CONTROLLED_SOURCES = [
     '$request->getParsedBody',
@@ -18,6 +19,14 @@ CONTROLLED_SOURCES = [
     '$request->getParams',
     '$request->getParam',
     '$args',
+    '$request->getAttribute',
+    '$request->getCookieParams',
+    '$request->getUploadedFiles',
 ]
 
-EXTRA_SINKS = []
+EXTRA_SINKS = [
+    ("$response->write(", [1000]),
+    ("$app->render(", [1000]),
+    ("$view->render(", [1000]),
+    ("$response->withRedirect(", [1009]),
+]

--- a/rules/tamper/php/symfony.py
+++ b/rules/tamper/php/symfony.py
@@ -13,6 +13,8 @@ def detect(project_dir, language='php'):
 FILTER_FUNCTIONS = {
     'escape': {'safe_for': [1000, 10001, 10002]},
     'htmlspecialchars': {'safe_for': [1000]},
+    'twig_escape': {'safe_for': [1000, 1010]},
+    'format_html': {'safe_for': [1000, 1010]},
 }
 
 CONTROLLED_SOURCES = [
@@ -22,10 +24,18 @@ CONTROLLED_SOURCES = [
     '$request->headers->get',
     '$request->getContent',
     'Request::get',
+    '$request->request->all',
+    '$request->query->all',
+    '$request->headers->all',
+    '$request->cookies->all',
 ]
 
 EXTRA_SINKS = [
     ("->createQuery(", [1004]),
     ("->executeQuery(", [1004]),
     ("Connection::executeQuery(", [1004]),
+    ("->render(", [1000]),
+    ("->renderView(", [1000]),
+    ("->redirect(", [1009]),
+    ("->redirectToRoute(", [1009]),
 ]

--- a/rules/tamper/php/thinkphp.py
+++ b/rules/tamper/php/thinkphp.py
@@ -11,11 +11,28 @@ def detect(project_dir, language='php'):
             or os.path.isfile(os.path.join(project_dir, 'tp5.php')))
 
 
-FILTER_FUNCTIONS = {}
+FILTER_FUNCTIONS = {
+    'think\\facade\\Validate': {'safe_for': [1000, 1001, 1004]},
+    'Db::where': {'safe_for': [1004]},  # param binding
+}
 
 EXTRA_SINKS = [
     ("Db::query(", [1004]),
     ("Db::execute(", [1004]),
+    ("->fetch(", [1000]),
+    ("->display(", [1000]),
+    ("redirect(", [1009]),
+    ("Db::name(", [1004]),
+    ("Cache::", [1004]),
 ]
 
-CONTROLLED_SOURCES = ['Input', 'request', 'I', 'input']
+CONTROLLED_SOURCES = [
+    'Input', 'request', 'I', 'input',
+    '$this->request->param',
+    '$this->request->get',
+    '$this->request->post',
+    '$this->request->header',
+    'request()->param',
+    'request()->get',
+    'request()->post',
+]

--- a/rules/tamper/php/wordpress.py
+++ b/rules/tamper/php/wordpress.py
@@ -21,9 +21,21 @@ FILTER_FUNCTIONS = {
     'tag_escape': {'safe_for': [1000]},
     'esc_sql': {'safe_for': [1000]},
     '_real_escape': {'safe_for': [1000]},
+    'wp_kses': {'safe_for': [1000, 1010]},
+    'wp_kses_post': {'safe_for': [1000, 1010]},
+    'sanitize_text_field': {'safe_for': [1000, 1010]},
+    'sanitize_email': {'safe_for': [1000]},
+    'sanitize_file_name': {'safe_for': [1006]},
+    'sanitize_title': {'safe_for': [1000]},
+    'absint': {'safe_for': [1004]},
+    'wp_nonce_url': {'safe_for': [1009]},
 }
 
-CONTROLLED_SOURCES = []
+CONTROLLED_SOURCES = [
+    'get_query_var',
+    '$wp_query->get',
+    'filter_input',
+]
 
 EXTRA_SINKS = [
     ('$wpdb->query', [1004]),
@@ -31,4 +43,13 @@ EXTRA_SINKS = [
     ('$wpdb->get_var', [1004]),
     ('$wpdb->get_row', [1004]),
     ('$wpdb->prepare', []),
+    ('wp_remote_get(', [1005]),
+    ('wp_remote_post(', [1005]),
+    ('wp_redirect(', [1009]),
+    ('include(', [1003]),
+    ('require(', [1003]),
+    ('$wpdb->insert(', [1004]),
+    ('$wpdb->update(', [1004]),
+    ('$wpdb->delete(', [1004]),
+    ('$wpdb->replace(', [1004]),
 ]

--- a/rules/tamper/php/yii2.py
+++ b/rules/tamper/php/yii2.py
@@ -14,6 +14,9 @@ def detect(project_dir, language='php'):
 FILTER_FUNCTIONS = {
     'Html::encode': {'safe_for': [1000, 10001, 10002]},
     'HtmlPurifier::process': {'safe_for': [1000, 10001, 10002]},
+    'Html::tag': {'safe_for': [1000, 1010]},
+    'Yii::$app->db->quoteValue': {'safe_for': [1004]},
+    'Yii::$app->security->hashData': {'safe_for': [1008]},
 }
 
 CONTROLLED_SOURCES = [
@@ -21,9 +24,19 @@ CONTROLLED_SOURCES = [
     'Yii::$app->request->post',
     'Yii::$app->request->getQueryParam',
     'Yii::$app->request->getBodyParam',
+    'Yii::$app->request->getQueryParams',
+    'Yii::$app->request->getBodyParams',
+    'Yii::$app->request->getHeaders',
+    'Yii::$app->request->getCookies',
+    'Yii::$app->request->getRawBody',
 ]
 
 EXTRA_SINKS = [
     ("->createCommand(", [1004]),
     ("Yii::\$app->db->createCommand(", [1004]),
+    ("->render(", [1000]),
+    ("->renderPartial(", [1000]),
+    ("->renderAjax(", [1000]),
+    ("->redirect(", [1009]),
+    ("Yii::\$app->response->redirect(", [1009]),
 ]

--- a/rules/tamper/python/aiohttp.py
+++ b/rules/tamper/python/aiohttp.py
@@ -7,6 +7,15 @@ DEPENDENCIES = {'requirements': ['aiohttp'], 'pyproject': ['aiohttp']}
 
 def detect(project_dir, language='python'):
     """检测是否为 aiohttp 项目"""
+    for fname in ['requirements.txt', 'pyproject.toml']:
+        dep_path = os.path.join(project_dir, fname)
+        if os.path.isfile(dep_path):
+            try:
+                with open(dep_path, 'r', encoding='utf-8', errors='ignore') as f:
+                    if 'aiohttp' in f.read().lower():
+                        return True
+            except IOError:
+                pass
     return False
 
 
@@ -17,6 +26,13 @@ CONTROLLED_SOURCES = [
     'request.match_info.get',
     'request.post',
     'request.json',
+    'request.headers',
+    'request.cookies',
+    'request.remote',
 ]
 
-EXTRA_SINKS = []
+EXTRA_SINKS = [
+    ("response.text", [7008]),
+    ("response.write(", [7008]),
+    ("aiohttp.ClientSession", [7004]),
+]

--- a/rules/tamper/python/django.py
+++ b/rules/tamper/python/django.py
@@ -12,12 +12,22 @@ def detect(project_dir, language='python'):
             or os.path.isfile(os.path.join(project_dir, 'wsgi.py')))
 
 
-FILTER_FUNCTIONS = {}
+FILTER_FUNCTIONS = {
+    # Django HTML 转义 / 安全 HTML 构造
+    'django.utils.html.escape': [7000, 7008],
+    'django.utils.html.format_html': [7000, 7008],
+    'django.utils.html.format_html_join': [7000, 7008],
+}
 
 EXTRA_SINKS = [
     (".objects.raw(", [7002]),
     (".objects.extra(", [7002]),
     ("cursor().execute(", [7002]),
+    ("render(", [7006]),
+    ("render_to_string(", [7006]),
+    ("HttpResponseRedirect(", [7010]),
+    ("redirect(", [7010]),
+    ("django.template.Template(", [7006]),
 ]
 
 CONTROLLED_SOURCES = [
@@ -28,4 +38,8 @@ CONTROLLED_SOURCES = [
     'request.META',
     'request.COOKIES',
     '@request.GET',
+    'self.kwargs',
+    'self.args',
+    'request.get_full_path',
+    'request.get_host',
 ]

--- a/rules/tamper/python/fastapi.py
+++ b/rules/tamper/python/fastapi.py
@@ -7,15 +7,34 @@ DEPENDENCIES = {'requirements': ['fastapi'], 'pyproject': ['fastapi']}
 
 def detect(project_dir, language='python'):
     """检测是否为 FastAPI 项目"""
-    # FastAPI 通常没有特征文件，依赖依赖检测
+    for fname in ['requirements.txt', 'pyproject.toml']:
+        dep_path = os.path.join(project_dir, fname)
+        if os.path.isfile(dep_path):
+            try:
+                with open(dep_path, 'r', encoding='utf-8', errors='ignore') as f:
+                    content = f.read().lower()
+                    if 'fastapi' in content:
+                        return True
+            except IOError:
+                pass
     return False
 
 
-FILTER_FUNCTIONS = {}
+FILTER_FUNCTIONS = {
+    # FastAPI HTML 响应（自动转义）
+    'HTMLResponse': [7000, 7008],
+}
 
-CONTROLLED_SOURCES = []
+CONTROLLED_SOURCES = [
+    'request.cookies',
+    'request.query_params',
+]
 
 EXTRA_SINKS = [
     ("Jinja2Templates(", [7006]),
     ("TemplateResponse(", [7006]),
+    ("RedirectResponse(", [7010]),
+    ("responses.RedirectResponse(", [7010]),
+    ("FileResponse(", [7005, 7009]),
+    ("StreamingResponse(", [7005]),
 ]

--- a/rules/tamper/python/flask.py
+++ b/rules/tamper/python/flask.py
@@ -16,10 +16,27 @@ def detect(project_dir, language='python'):
     return False
 
 
-FILTER_FUNCTIONS = {}
+FILTER_FUNCTIONS = {
+    # HTML 转义 / 安全输出（Flask 内置 escape 别名）
+    'flask.escape': [7000, 7008],
+    # 安全 URL 生成（不会产生开放重定向）
+    'url_for': [7010],
+    # 安全 JSON 输出（Content-Type 为 application/json）
+    'jsonify': [7000, 7008],
+}
 
 EXTRA_SINKS = [
     ("render_template_string(", [7006]),
+    ("render_template(", [7006]),
+    ("render_template_list(", [7006]),
+    ("redirect(", [7010]),
+    ("send_file(", [7005]),
+    ("send_from_directory(", [7005, 7009]),
 ]
 
-CONTROLLED_SOURCES = ['flask.request']
+CONTROLLED_SOURCES = [
+    'flask.request',
+    'request.query_string',
+    'request.cookies',
+    'session',
+]

--- a/rules/tamper/python/tornado.py
+++ b/rules/tamper/python/tornado.py
@@ -7,10 +7,23 @@ DEPENDENCIES = {'requirements': ['tornado'], 'pyproject': ['tornado']}
 
 def detect(project_dir, language='python'):
     """检测是否为 Tornado 项目"""
+    for fname in ['requirements.txt', 'pyproject.toml']:
+        dep_path = os.path.join(project_dir, fname)
+        if os.path.isfile(dep_path):
+            try:
+                with open(dep_path, 'r', encoding='utf-8', errors='ignore') as f:
+                    if 'tornado' in f.read().lower():
+                        return True
+            except IOError:
+                pass
     return False
 
 
-FILTER_FUNCTIONS = {}
+FILTER_FUNCTIONS = {
+    # Tornado HTML / URL 转义
+    'tornado.escape.xhtml_escape': [7000, 7008],
+    'tornado.escape.url_escape': [7004, 7010],
+}
 
 CONTROLLED_SOURCES = [
     'self.get_argument',
@@ -22,4 +35,7 @@ CONTROLLED_SOURCES = [
 
 EXTRA_SINKS = [
     ("self.render(", [7006]),
+    ("self.render_string(", [7006]),
+    ("self.write(", [7008]),
+    ("self.redirect(", [7010]),
 ]


### PR DESCRIPTION
Bug 修复:
- Go _base.py: 删除 template.HTML (非修复函数)
- Java _base.py: 删除 ProcessBuilder (是命令执行 sink)
- JS _base.py: 删除 Buffer.from/crypto.createHash (不做 HTML 转义)
- Java mybatis.py: CVI 1004(PHP) → 6031(Java)
- Laravel detect: Kernel.py → Kernel.php

detect() 修复 (从 bare return False 改为实际检测):
- Python: tornado, fastapi, aiohttp
- JavaScript: koa, fastify
- Go: echo, fiber, chi, beego
- Java: mybatis

框架配置完善 (28 个框架，+496 行):
- PHP: laravel, thinkphp, codeigniter, yii2, symfony, slim, drupal, wordpress, phpbb, roundcube
- Python: flask, django, tornado, fastapi, aiohttp
- JavaScript: express, nextjs, nestjs, koa, fastify
- Go: gin, echo, fiber, chi, beego
- Java: spring, struts2, mybatis